### PR TITLE
Add basis mutex to prevent multiple read derived panic from goroutines

### DIFF
--- a/service/guacamole.go
+++ b/service/guacamole.go
@@ -14,7 +14,11 @@ func GetGuacamoleToken(uuid structure.UUID, ctx *structure.ControlContext) (stri
 		return "", structure.ErrCoreNotFound(uuid)
 	}
 
-	if vm, exists := core.VMInfoIdx[uuid]; exists {
+	ctx.RLock()
+	vm, exists := core.VMInfoIdx[uuid]
+	ctx.RUnlock()
+
+	if exists {
 		guacClient := client.NewGuacamoleClient(&ctx.Config)
 
 		err := guacClient.Authenticate(context.Background(), string(uuid), vm.GuacPassword)

--- a/service/network.go
+++ b/service/network.go
@@ -145,6 +145,9 @@ func (c *CmsClient) NewCmsSubnet(ctx *vms.ControlContext) (*CmsResponse, error) 
 }
 
 func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {
+	ctx.RLock()
+	defer ctx.RUnlock()
+
 	core, ok := ctx.VMLocation[uuid]
 	if !ok {
 		return "", fmt.Errorf("UUID %s not found in VMLocation", uuid)

--- a/service/vm.go
+++ b/service/vm.go
@@ -35,6 +35,8 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	selectedCoreIndex := -1
 	aliveCount := 0
 
+	// Cores/FreeMemory 등 공유 상태를 읽으므로 RLock (동시 읽기는 허용, 쓰기만 차단)
+	contextStruct.RLock()
 	for i := range contextStruct.Cores {
 
 		core := &contextStruct.Cores[i]
@@ -73,6 +75,8 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 			log.DebugInfo("%s rejected: memory=%t, cpu=%t, disk=%t", core.IP, memoryOk, cpuOk, diskOk)
 		}
 	}
+	// 코어 탐색 완료 후 즉시 해제 — 이후 CMS/Guacamole 네트워크 콜은 락 없이 진행
+	contextStruct.RUnlock()
 
 	if selectedCore == nil {
 		log.Error("No suitable core found! Total cores: %d, Alive cores: %d, Required: Memory=%d CPU=%d Disk=%d",
@@ -116,10 +120,13 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 			}
 		}
 		if coreResourcesAllocated {
+			// VMInfoIdx와 Free* 필드는 여러 핸들러가 동시에 접근하므로 Lock 필요
+			contextStruct.Lock()
 			delete(selectedCore.VMInfoIdx, uuid)
 			selectedCore.FreeMemory += req.HardwareInfo.Memory
 			selectedCore.FreeCPU += req.HardwareInfo.CPU
 			selectedCore.FreeDisk += req.HardwareInfo.Disk
+			contextStruct.Unlock()
 		}
 		if newSubnetAllocated {
 			//subnet--
@@ -162,7 +169,9 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		IP_VM:        cmsResp.IP,
 	}
 
-	// selected core 상태 업데이트
+	// VMInfoIdx map 쓰기 + Free* 필드 감소는 원자적으로 처리해야 함
+	// (다른 CreateVM goroutine이 Free* 읽고 같은 코어 선택하는 race 방지)
+	contextStruct.Lock()
 	if selectedCore.VMInfoIdx == nil {
 		selectedCore.VMInfoIdx = make(map[vms.UUID]*vms.VMInfo)
 	}
@@ -171,6 +180,8 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	selectedCore.FreeCPU -= req.HardwareInfo.CPU
 	selectedCore.FreeDisk -= req.HardwareInfo.Disk
 	coreResourcesAllocated = true
+	contextStruct.Unlock()
+	// 이후 HTTP 전송은 락 밖에서 — 네트워크 콜 중 락을 잡으면 다른 요청 전체가 블로킹됨
 
 	log.DebugInfo("core %s updated: FreeMemory=%d, FreeCPU=%d, FreeDisk=%d", selectedCore.IP, selectedCore.FreeMemory, selectedCore.FreeCPU, selectedCore.FreeDisk)
 
@@ -218,12 +229,15 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		}
 	}
 
-	// ControlContext global 상태 업데이트
+	// VMLocation map과 AliveVM slice를 하나의 Lock으로 묶어 일관성 보장
+	// (VMLocation에는 있는데 AliveVM에는 없는 중간 상태가 노출되지 않도록)
+	contextStruct.Lock()
 	if contextStruct.VMLocation == nil {
 		contextStruct.VMLocation = make(map[vms.UUID]*vms.Core)
 	}
 	contextStruct.VMLocation[uuid] = &contextStruct.Cores[selectedCoreIndex]
 	contextStruct.AliveVM = append(contextStruct.AliveVM, newVM)
+	contextStruct.Unlock()
 	log.Info("VM %s added to ControlContext", uuid, true)
 
 	log.Info("UUID %s CreateVM request success on core %s", uuid, selectedCore.IP, true)
@@ -301,6 +315,8 @@ func ShutdownVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Cli
 	}
 
 	foundIndex := -1
+	// 탐색과 삭제를 하나의 Lock 안에서 — 탐색 후 삭제 전에 다른 goroutine이 AliveVM을 바꾸면 index가 틀어짐
+	contextStruct.Lock()
 	for i, vm := range contextStruct.AliveVM {
 		if vm.UUID == uuid {
 			foundIndex = i
@@ -311,6 +327,7 @@ func ShutdownVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Cli
 	if foundIndex != -1 {
 		contextStruct.AliveVM = slices.Delete(contextStruct.AliveVM, foundIndex, foundIndex+1)
 	}
+	contextStruct.Unlock()
 
 	if err := UpdateVMStatusInRedis(context.Background(), rdb, uuid, model.VMStatusStopped, time.Now().Unix()); err != nil {
 		log := util.GetLogger()

--- a/structure/control_infra.go
+++ b/structure/control_infra.go
@@ -3,12 +3,14 @@ package structure
 import (
 	"context"
 	"database/sql"
+	"sync"
 	"time"
 
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
 type ControlContext struct {
+	mu          sync.RWMutex
 	Config      Config
 	DB          *sql.DB
 	GuacDB      *sql.DB
@@ -20,6 +22,11 @@ type ControlContext struct {
 	// => 근데 이거 자료형을 어떤걸 써야할지 모르겠어서 일단 이렇게 map[UUID]*Core로 해놓은거지 2차원 벡터로 해도 무방할거 같습니다.
 	// => 이렇게 한 이유는 이전 버전에서 VMPool map[UUID]*VM 이렇게 해놓았던데 이렇게 하면 VM이 많아졌을 때 너무 오래 걸릴거 같아서 IP를 기반으로 먼저 찾고 해당 core로 넘어가서 처리하면 더 좋지않을까? 생각했어요.
 }
+
+func (c *ControlContext) Lock()    { c.mu.Lock() }
+func (c *ControlContext) Unlock()  { c.mu.Unlock() }
+func (c *ControlContext) RLock()   { c.mu.RLock() }
+func (c *ControlContext) RUnlock() { c.mu.RUnlock() }
 
 func (c *ControlContext) FindCoreByVmUUID(uuid UUID) *Core {
 	log := util.GetLogger()


### PR DESCRIPTION
## Summary

mutex 접근시 기본적으로 Panic 에러가 발생합니다. 
이를 방지하기 위해 뮤택스를 추가했습니다.

## Motivation

패닉 방지입니다. 

## Approach
조작하는 부분 특히 `CreateVM`은 로직이 섞여있어 Lock -> Unlock 이 defer 가 아니라 원자적으로 수행합니다.
중간에 에러등 발생시 Race컨디션 등 생길 확률 매우 높음.

또한 list 도 append 나 delete 등 레이스 컨디션이 발생할 수 있는데, 하나의 RWmutex로 모두 관리할건지 결정이 필요해보입니다.

코드 분리를 잘해서 defer 로 처리하도록 방지해야함.(마이그레이션 이후)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Docs / Config
- [ ] CI/CD

## Related Issue

#30
## Testing
- [x] Tested locally
- [ ] No regression in existing functionality

## Checklist

- [ ] Reviewers assigned
- [ ] Related issue linked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety and stability for concurrent VM operations, including authentication, network lookups, VM creation, and shutdown processes.
  * Enhanced consistency guarantees for core state and resource allocation tracking during simultaneous system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->