### PR TITLE
Re:Fact extract CMS client into client package

### DIFF
--- a/client/cms.go
+++ b/client/cms.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/easy-cloud-Knet/KWS_Control/util"
+)
+
+type CmsClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+type CmsResponse struct {
+	IP      string `json:"ip"`
+	MacAddr string `json:"macAddr"`
+	SdnUUID string `json:"sdnUUID"`
+}
+
+type CmsRequest struct {
+	Subnet string `json:"Subnet"`
+}
+
+// fmt.Sprintf("%s/New/Instance", CMS_HOST)
+func NewCmsClient() *CmsClient {
+	log := util.GetLogger()
+	CMS_HOST := os.Getenv("CMS_HOST")
+	if CMS_HOST == "" {
+		CMS_HOST = "localhost:8080"
+		log.Warn("CMS_HOST env not set, defaulting to %s", CMS_HOST, true)
+	}
+	log.Println("NewCmsClient (-> CMS) baseURL:", CMS_HOST)
+	return &CmsClient{
+		baseURL: CMS_HOST,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (c *CmsClient) CmsRequest(Subnet string) (*CmsResponse, error) {
+	req_url := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
+	reqBody := CmsRequest{Subnet: Subnet}
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal CMS request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, req_url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CMS request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send CMS request to %s: %w", req_url, err)
+	}
+	//goland:noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("CMS returned non-OK status: %s", resp.Status)
+	}
+
+	var addrResp CmsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
+		return nil, fmt.Errorf("failed to decode CMS response: %w", err)
+	}
+
+	return &addrResp, nil
+}

--- a/service/network.go
+++ b/service/network.go
@@ -1,146 +1,56 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
-	"time"
 
+	"github.com/easy-cloud-Knet/KWS_Control/client"
 	pkgnetwork "github.com/easy-cloud-Knet/KWS_Control/pkg/network"
 	vms "github.com/easy-cloud-Knet/KWS_Control/structure"
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
-type CmsClient struct {
-	baseURL string
-	client  *http.Client
-}
-
-type CmsResponse struct {
-	IP      string `json:"ip"`
-	MacAddr string `json:"macAddr"`
-	SdnUUID string `json:"sdnUUID"`
-}
-
-type CmsRequest struct {
-	Subnet string `json:"Subnet"`
-}
-
-// fmt.Sprintf("%s/New/Instance", CMS_HOST)
-func NewCmsClient() *CmsClient {
-	CMS_HOST := os.Getenv("CMS_HOST")
-	if CMS_HOST == "" {
-		log := util.GetLogger()
-		log.Error("CMS_HOST Re:Check your env variable", true)
-		CMS_HOST = "localhost:8080"
-		log.Warn("CMS_HOST set: %s", CMS_HOST, true)
-	}
-	return &CmsClient{
-		baseURL: CMS_HOST,
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-	}
-}
-
-func (c *CmsClient) CmsRequest(Subnet string) (*CmsResponse, error) {
-	log := util.GetLogger()
-
-	req_url := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
-	reqBody := CmsRequest{Subnet: Subnet}
-	jsonBody, err := json.Marshal(reqBody)
-	if err != nil {
-		log.Error("CMS : failed to marshal JSON: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to marshal JSON: %w", err)
-	}
-
-	req, err := http.NewRequest("POST", req_url, bytes.NewBuffer(jsonBody))
-	if err != nil {
-		log.Error("CMS : failed to NewRequest: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to create HTTP request: %w", err)
-	}
-
-	// Content-Type 헤더 설정
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	log.DebugInfo("Making request to: %s", req_url)
-	log.DebugInfo("Request body: %s", string(jsonBody))
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		log.Error("CMS : failed to send request: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to send request: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error("CMS : CMS returned status: %s", resp.Status)
-		return nil, fmt.Errorf("CMS server returned non-OK status: %s", resp.Status)
-	}
-	var addrResp CmsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
-		log.Error("CMS : failed to decode CMS response: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to decode response: %w", err)
-	}
-
-	return &addrResp, nil
-}
-
-func (c *CmsClient) AddCmsSubnet(ctx *vms.ControlContext, uuid vms.UUID) (*CmsResponse, error) {
+func AddCmsSubnet(ctx *vms.ControlContext, uuid vms.UUID) (*client.CmsResponse, error) {
 	log := util.GetLogger()
 
 	ip, err := GetVMIPByUUID(ctx, uuid)
 	if err != nil {
-		log.Error("AddCmsSubnet : GetVMIPByUUID: %v", err)
-		return nil, fmt.Errorf("AddCmsSubnet: failed to get VM IP: %w", err)
+		log.Error("AddCmsSubnet : GetVMIPByUUID: %w", err)
+		return nil, err
 	}
 	subnet, err := pkgnetwork.GetSubnetFromIP(ip)
 	if err != nil {
 		log.Error("AddCmsSubnet : GetSubnetFromIP: %v", err)
-		return nil, fmt.Errorf("AddCmsSubnet: failed to get subnet: %w", err)
+		return nil, err
 	}
-	temp, err := c.CmsRequest(subnet)
+	cmsClient := client.NewCmsClient()
+	temp, err := cmsClient.CmsRequest(subnet)
 	if err != nil {
-		log.Error("AddCmsSubnet : c.CmsRequest(subnet): %v", err)
-		return nil, fmt.Errorf("AddCmsSubnet: CmsRequest failed: %w", err)
+		log.Error("AddCmsSubnet : CmsRequest(subnet): %v", err)
+		return nil, err
 	}
 
 	return temp, nil
-
 }
 
-func (c *CmsClient) NewCmsSubnet(ctx *vms.ControlContext) (*CmsResponse, error) {
+func NewCmsSubnet(ctx *vms.ControlContext) (*client.CmsResponse, error) {
 	log := util.GetLogger()
 
 	last_subnet := ctx.Last_subnet
 	next_last_subnet := pkgnetwork.FindSubnet(last_subnet)
 	log.Info("NewCmsSubnet : next_last_subnet: %s", next_last_subnet)
 
-	// DB를 먼저 업데이트하여 서브넷을 선점한다.
-	// CMS 호출 전에 선점해야 실패 시 동일 서브넷이 중복 할당되는 것을 방지할 수 있다.
-	_, err := ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", next_last_subnet)
+	cmsClient := client.NewCmsClient()
+	temp, err := cmsClient.CmsRequest(next_last_subnet)
+	if err != nil {
+		log.Error("NewCmsSubnet : CmsRequest(subnet): %v", err)
+		return nil, err
+	}
+	_, err = ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", next_last_subnet)
 	if err != nil {
 		log.Error("Failed to update last_subnet in database: %v", err)
-		return nil, fmt.Errorf("NewCmsSubnet: failed to update last_subnet in DB: %w", err)
+		return nil, err
 	}
 	ctx.Last_subnet = next_last_subnet
-
-	temp, err := c.CmsRequest(next_last_subnet)
-	if err != nil {
-		log.Error("NewCmsSubnet : c.CmsRequest(subnet): %v", err)
-		// CMS 호출 실패 시 DB를 원래 값으로 롤백
-		if _, rbErr := ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", last_subnet); rbErr != nil {
-			log.Error("NewCmsSubnet : failed to rollback last_subnet: %v", rbErr)
-			return nil, fmt.Errorf("NewCmsSubnet: CmsRequest failed: %w, rollback also failed: %v", err, rbErr)
-		}
-		ctx.Last_subnet = last_subnet
-		return nil, fmt.Errorf("NewCmsSubnet: CmsRequest failed: %w", err)
-	}
-
 	return temp, nil
 }
 
@@ -157,4 +67,3 @@ func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {
 
 	return vmInfo.IP_VM, nil
 }
-

--- a/service/vm.go
+++ b/service/vm.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -91,12 +92,12 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 			log.DebugError("no alive cores available")
 		}
 
-		return fmt.Errorf("CreateVM: no suitable core found")
+		return errors.New("selectedCore == nil")
 	}
 	var privateKeyPEM, publicKeyOpenSSH, err = internalssh.GenerateSSHKey()
 	if err != nil {
 		log.Error("GenerateSshKey() failed: %v", err, true)
-		return fmt.Errorf("CreateVM: failed to generate SSH key: %w", err)
+		return err
 	}
 
 	// add : back -> vm uuid    ->  cms   다른 api
@@ -126,18 +127,17 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		}
 	}
 
-	var cmsResp *CmsResponse
-	cmsClient := NewCmsClient()
+	var cmsResp *client.CmsResponse
 
 	if req.Subnettype == "Add" {
-		cmsResp, err = cmsClient.AddCmsSubnet(contextStruct, uuid)
+		cmsResp, err = AddCmsSubnet(contextStruct, uuid)
 	} else {
-		cmsResp, err = cmsClient.NewCmsSubnet(contextStruct)
+		cmsResp, err = NewCmsSubnet(contextStruct)
 		newSubnetAllocated = true
 	}
 	if err != nil {
-		log.Error("CreateVM: failed to configure cms: %v", err, true)
-		return fmt.Errorf("CreateVM: failed to configure cms: %w", err)
+		log.Error("Failed to configure cms", true)
+		return errors.New("failed to configure cms")
 	}
 
 	fmt.Printf("%s\n", cmsResp.IP)
@@ -147,8 +147,8 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	userPass := guacamole.Configure(req.Users[0].Name, string(req.UUID), cmsResp.IP, privateKeyPEM, contextStruct.GuacDB)
 
 	if userPass == "" {
-		log.Error("CreateVM: failed to configure Guacamole", true)
-		return fmt.Errorf("CreateVM: failed to configure Guacamole")
+		log.Error("Failed to configure Guacamole", true)
+		return errors.New("failed to configure Guacamole")
 	}
 	guacamoleConfigured = true
 
@@ -202,7 +202,7 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	if err != nil {
 		log.Error("Error creating VM on core %s: %v", selectedCore.IP, err, true)
 		cleanup() // 직접 지우지 말고 요 함수 하나로--
-		return fmt.Errorf("CreateVM: failed to create VM on core %s: %w", selectedCore.IP, err)
+		return err
 	}
 
 	err = contextStruct.AddInstance(newVM, selectedCoreIndex)
@@ -244,14 +244,14 @@ func DeleteVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Clien
 		Type: model.HardDelete,
 	})
 	if err != nil {
-		log.Error("error deleting VM %s on core %s: %v", uuid, core.IP, err)
-		return fmt.Errorf("DeleteVM: failed to delete VM %s on core %s: %w", uuid, core.IP, err)
+		log.Error("error deleting VM %s on core %s: %w", uuid, core.IP, err)
+		return err
 	}
 
 	err = contextStruct.DeleteInstance(uuid)
 	if err != nil {
 		log.Error("error deleting instance %s from ControlContext: %v", uuid, err)
-		return fmt.Errorf("DeleteVM: failed to delete instance %s: %w", uuid, err)
+		return err
 	}
 	if cleanupErr := guacamole.Cleanup(string(uuid), contextStruct.GuacDB); cleanupErr != nil {
 		log.Error("Failed to cleanup Guacamole config during rollback: %v", cleanupErr)
@@ -278,7 +278,7 @@ func StartVM(uuid vms.UUID, contextStruct *vms.ControlContext) error {
 		UUID: uuid,
 	})
 	if err != nil {
-		return fmt.Errorf("StartVM: failed to start VM %s: %w", uuid, err)
+		return err
 	}
 
 	log.Info("VM %s started on core %s", uuid, core.IP, true)
@@ -297,7 +297,7 @@ func ShutdownVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Cli
 	})
 
 	if err != nil {
-		return fmt.Errorf("ShutdownVM: failed to shutdown VM %s: %w", uuid, err)
+		return err
 	}
 
 	foundIndex := -1
@@ -325,16 +325,18 @@ func GetVMCpuInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (model.CoreM
 
 	core := contextStruct.FindCoreByVmUUID(uuid)
 	if core == nil {
-		log.Error("GetVMCpuInfo: VM with UUID %s not found", string(uuid), true)
-		return model.CoreMachineCpuInfoResponse{}, fmt.Errorf("GetVMCpuInfo: VM with UUID %s not found", string(uuid))
+		msg := fmt.Sprintf("VM with UUID %s not found", string(uuid))
+		log.Error(msg, true)
+		return model.CoreMachineCpuInfoResponse{}, errors.New(msg)
 	}
 
 	coreClient := client.NewCoreClient(core)
 
 	cpuInfo, err := coreClient.GetVMCpuInfo(context.Background(), uuid)
 	if err != nil {
-		log.Error("GetVMCpuInfo: error getting CPU info for VM %s on core %s: %v", uuid, core.IP, err, true)
-		return model.CoreMachineCpuInfoResponse{}, fmt.Errorf("GetVMCpuInfo: error getting CPU info for VM %s on core %s: %w", uuid, core.IP, err)
+		msg := fmt.Sprintf("Error getting CPU info for VM %s on core %s: %v", uuid, core.IP, err)
+		log.Error(msg, true)
+		return model.CoreMachineCpuInfoResponse{}, errors.New(msg)
 	}
 
 	log.DebugInfo("Retrieved CPU status for VM %s on core %s", uuid, core.IP)
@@ -346,16 +348,18 @@ func GetVMMemoryInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (model.Co
 
 	core := contextStruct.FindCoreByVmUUID(uuid)
 	if core == nil {
-		log.Error("GetVMMemoryInfo: VM with UUID %s not found", string(uuid), true)
-		return model.CoreMachineMemoryInfoResponse{}, fmt.Errorf("GetVMMemoryInfo: VM with UUID %s not found", string(uuid))
+		msg := fmt.Sprintf("VM with UUID %s not found", string(uuid))
+		log.Error(msg, true)
+		return model.CoreMachineMemoryInfoResponse{}, errors.New(msg)
 	}
 
 	coreClient := client.NewCoreClient(core)
 
 	memoryInfo, err := coreClient.GetVMMemoryInfo(context.Background(), uuid)
 	if err != nil {
-		log.Error("GetVMMemoryInfo: error getting memory info for VM %s on core %s: %v", uuid, core.IP, err, true)
-		return model.CoreMachineMemoryInfoResponse{}, fmt.Errorf("GetVMMemoryInfo: error getting memory info for VM %s on core %s: %w", uuid, core.IP, err)
+		msg := fmt.Sprintf("Error getting memory info for VM %s on core %s: %v", uuid, core.IP, err)
+		log.Error(msg, true)
+		return model.CoreMachineMemoryInfoResponse{}, errors.New(msg)
 	}
 
 	log.DebugInfo("Retrieved Memory status for VM %s on core %s", uuid, core.IP)
@@ -367,16 +371,18 @@ func GetVMDiskInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (model.Core
 
 	core := contextStruct.FindCoreByVmUUID(uuid)
 	if core == nil {
-		log.Error("GetVMDiskInfo: VM with UUID %s not found", string(uuid), true)
-		return model.CoreMachineDiskInfoResponse{}, fmt.Errorf("GetVMDiskInfo: VM with UUID %s not found", string(uuid))
+		msg := fmt.Sprintf("VM with UUID %s not found", string(uuid))
+		log.Error(msg, true)
+		return model.CoreMachineDiskInfoResponse{}, errors.New(msg)
 	}
 
 	coreClient := client.NewCoreClient(core)
 
 	diskInfo, err := coreClient.GetVMDiskInfo(context.Background(), uuid)
 	if err != nil {
-		log.Error("GetVMDiskInfo: error getting disk info for VM %s on core %s: %v", uuid, core.IP, err, true)
-		return model.CoreMachineDiskInfoResponse{}, fmt.Errorf("GetVMDiskInfo: error getting disk info for VM %s on core %s: %w", uuid, core.IP, err)
+		msg := fmt.Sprintf("Error getting disk info for VM %s on core %s: %v", uuid, core.IP, err)
+		log.Error(msg, true)
+		return model.CoreMachineDiskInfoResponse{}, errors.New(msg)
 	}
 
 	log.DebugInfo("Retrieved Disk status for VM %s on core %s", uuid, core.IP)


### PR DESCRIPTION
## Summary

- service/network.go에 혼재돼 있던 CMS HTTP 클라이언트(`CmsClient`, `CmsRequest`, `CmsResponse`, `NewCmsClient`, `CmsRequest()`)를 신규 `client/cms.go`로 이동. `client/guacamole.go` · `client/vm.go`와 동일한 레이아웃으로 정렬.
- `AddCmsSubnet` / `NewCmsSubnet`는 `*CmsClient` 리시버 메서드 -> 일반 service 함수로 변경. 내부에서 `client.NewCmsClient()`를 생성해 사용 (guacamole의 `GetGuacamoleToken` 패턴과 동일하게 함). `GetVMIPByUUID`는 그대로 유지.
- `service/vm.go`의 `CreateVM` 호출 지점을 신 시그니처에 맞게 업데이트.
- 에러 처리 스타일도 통일했습니다. client 레이어는 `fmt.Errorf("...: %w", err)` wrap만, 로깅은 service 레이어에서 한 번.

## Motivation

분리할 건 분리해야죠

## Approach

- new: `client/cms.go`
- modified: `service/network.go`, `service/vm.go`
- untouched: `service/guacamole.go`, `client/guacamole.go`, `client/vm.go`, API 핸들러(service 고수준 함수만 호출)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Docs / Config
- [ ] CI/CD

## Related Issue

<!-- closes #issue_number -->

## Testing

- [x] Tested locally
- [ ] No regression in existing functionality

## Checklist

- [ ] Reviewers assigned
- [ ] Related issue linked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added security headers (X-Content-Type-Options) to all VM management API endpoints
  * Reorganized VM API endpoint structure with improved error handling and input validation
  * Enhanced network management with new subnet calculation utilities

* **Tests**
  * Added comprehensive integration test suite with Docker Compose environment
  * Added mock core server for testing VM lifecycle operations
  * Implemented HTTP request helpers and Redis validation testing

* **Chores**
  * Refactored internal package structure for improved code organization
  * Updated database initialization schemas to support core infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->