### PR TITLE
refactor: extract CMS client into client package

### DIFF
--- a/client/cms.go
+++ b/client/cms.go
@@ -11,7 +11,7 @@ import (
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
-type SubnetClient struct {
+type CmsClient struct {
 	baseURL string
 	client  *http.Client
 }
@@ -26,7 +26,7 @@ type subnetRequest struct {
 	Subnet string `json:"Subnet"`
 }
 
-func NewSubnetClient() *SubnetClient {
+func NewCmsClient() *CmsClient {
 	CMS_HOST := os.Getenv("CMS_HOST")
 	if CMS_HOST == "" {
 		log := util.GetLogger()
@@ -34,7 +34,7 @@ func NewSubnetClient() *SubnetClient {
 		CMS_HOST = "localhost:8080"
 		log.Warn("CMS_HOST set: %s", CMS_HOST, true)
 	}
-	return &SubnetClient{
+	return &CmsClient{
 		baseURL: CMS_HOST,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
@@ -42,7 +42,7 @@ func NewSubnetClient() *SubnetClient {
 	}
 }
 
-func (c *SubnetClient) RequestSubnet(subnet string) (*NewSubnetRequest, error) {
+func (c *CmsClient) RequestSubnet(subnet string) (*NewSubnetRequest, error) {
 	log := util.GetLogger()
 
 	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)

--- a/client/cms.go
+++ b/client/cms.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/easy-cloud-Knet/KWS_Control/util"
+)
+
+type CmsClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+type CmsResponse struct {
+	IP      string `json:"ip"`
+	MacAddr string `json:"macAddr"`
+	SdnUUID string `json:"sdnUUID"`
+}
+
+type CmsRequest struct {
+	Subnet string `json:"Subnet"`
+}
+
+func NewCmsClient() *CmsClient {
+	CMS_HOST := os.Getenv("CMS_HOST")
+	if CMS_HOST == "" {
+		log := util.GetLogger()
+		log.Error("CMS_HOST Re:Check your env variable", true)
+		CMS_HOST = "localhost:8080"
+		log.Warn("CMS_HOST set: %s", CMS_HOST, true)
+	}
+	return &CmsClient{
+		baseURL: CMS_HOST,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (c *CmsClient) RequestSubnet(subnet string) (*CmsResponse, error) {
+	log := util.GetLogger()
+
+	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
+	reqBody := CmsRequest{Subnet: subnet}
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		log.Error("CMS : failed to marshal JSON: %v", err)
+		return nil, fmt.Errorf("RequestSubnet: failed to marshal JSON: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", reqURL, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		log.Error("CMS : failed to NewRequest: %v", err)
+		return nil, fmt.Errorf("RequestSubnet: failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	log.DebugInfo("Making request to: %s", reqURL)
+	log.DebugInfo("Request body: %s", string(jsonBody))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Error("CMS : failed to send request: %v", err)
+		return nil, fmt.Errorf("RequestSubnet: failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Error("CMS : CMS returned status: %s", resp.Status)
+		return nil, fmt.Errorf("CMS server returned non-OK status: %s", resp.Status)
+	}
+
+	var addrResp CmsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
+		log.Error("CMS : failed to decode CMS response: %v", err)
+		return nil, fmt.Errorf("RequestSubnet: failed to decode response: %w", err)
+	}
+
+	return &addrResp, nil
+}

--- a/client/cms.go
+++ b/client/cms.go
@@ -11,22 +11,22 @@ import (
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
-type CmsClient struct {
+type SubnetClient struct {
 	baseURL string
 	client  *http.Client
 }
 
-type CmsResponse struct {
+type NewSubnetRequest struct {
 	IP      string `json:"ip"`
 	MacAddr string `json:"macAddr"`
 	SdnUUID string `json:"sdnUUID"`
 }
 
-type CmsRequest struct {
+type subnetRequest struct {
 	Subnet string `json:"Subnet"`
 }
 
-func NewCmsClient() *CmsClient {
+func NewSubnetClient() *SubnetClient {
 	CMS_HOST := os.Getenv("CMS_HOST")
 	if CMS_HOST == "" {
 		log := util.GetLogger()
@@ -34,7 +34,7 @@ func NewCmsClient() *CmsClient {
 		CMS_HOST = "localhost:8080"
 		log.Warn("CMS_HOST set: %s", CMS_HOST, true)
 	}
-	return &CmsClient{
+	return &SubnetClient{
 		baseURL: CMS_HOST,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
@@ -42,11 +42,11 @@ func NewCmsClient() *CmsClient {
 	}
 }
 
-func (c *CmsClient) RequestSubnet(subnet string) (*CmsResponse, error) {
+func (c *SubnetClient) RequestSubnet(subnet string) (*NewSubnetRequest, error) {
 	log := util.GetLogger()
 
 	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
-	reqBody := CmsRequest{Subnet: subnet}
+	reqBody := subnetRequest{Subnet: subnet}
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
 		log.Error("CMS : failed to marshal JSON: %v", err)
@@ -77,7 +77,7 @@ func (c *CmsClient) RequestSubnet(subnet string) (*CmsResponse, error) {
 		return nil, fmt.Errorf("CMS server returned non-OK status: %s", resp.Status)
 	}
 
-	var addrResp CmsResponse
+	var addrResp NewSubnetRequest
 	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
 		log.Error("CMS : failed to decode CMS response: %v", err)
 		return nil, fmt.Errorf("RequestSubnet: failed to decode response: %w", err)

--- a/service/network.go
+++ b/service/network.go
@@ -9,7 +9,7 @@ import (
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
-func AddCmsSubnet(c *client.SubnetClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.NewSubnetRequest, error) {
+func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.NewSubnetRequest, error) {
 	log := util.GetLogger()
 
 	ip, err := GetVMIPByUUID(ctx, uuid)
@@ -31,7 +31,7 @@ func AddCmsSubnet(c *client.SubnetClient, ctx *vms.ControlContext, uuid vms.UUID
 	return resp, nil
 }
 
-func NewCmsSubnet(c *client.SubnetClient, ctx *vms.ControlContext) (*client.NewSubnetRequest, error) {
+func NewCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext) (*client.NewSubnetRequest, error) {
 	log := util.GetLogger()
 
 	last_subnet := ctx.Last_subnet

--- a/service/network.go
+++ b/service/network.go
@@ -9,7 +9,7 @@ import (
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
-func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.CmsResponse, error) {
+func AddCmsSubnet(c *client.SubnetClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.NewSubnetRequest, error) {
 	log := util.GetLogger()
 
 	ip, err := GetVMIPByUUID(ctx, uuid)
@@ -31,7 +31,7 @@ func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (
 	return resp, nil
 }
 
-func NewCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext) (*client.CmsResponse, error) {
+func NewCmsSubnet(c *client.SubnetClient, ctx *vms.ControlContext) (*client.NewSubnetRequest, error) {
 	log := util.GetLogger()
 
 	last_subnet := ctx.Last_subnet

--- a/service/network.go
+++ b/service/network.go
@@ -1,96 +1,15 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
-	"time"
 
+	"github.com/easy-cloud-Knet/KWS_Control/client"
 	pkgnetwork "github.com/easy-cloud-Knet/KWS_Control/pkg/network"
 	vms "github.com/easy-cloud-Knet/KWS_Control/structure"
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
-type CmsClient struct {
-	baseURL string
-	client  *http.Client
-}
-
-type CmsResponse struct {
-	IP      string `json:"ip"`
-	MacAddr string `json:"macAddr"`
-	SdnUUID string `json:"sdnUUID"`
-}
-
-type CmsRequest struct {
-	Subnet string `json:"Subnet"`
-}
-
-// fmt.Sprintf("%s/New/Instance", CMS_HOST)
-func NewCmsClient() *CmsClient {
-	CMS_HOST := os.Getenv("CMS_HOST")
-	if CMS_HOST == "" {
-		log := util.GetLogger()
-		log.Error("CMS_HOST Re:Check your env variable", true)
-		CMS_HOST = "localhost:8080"
-		log.Warn("CMS_HOST set: %s", CMS_HOST, true)
-	}
-	return &CmsClient{
-		baseURL: CMS_HOST,
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-	}
-}
-
-func (c *CmsClient) CmsRequest(Subnet string) (*CmsResponse, error) {
-	log := util.GetLogger()
-
-	req_url := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
-	reqBody := CmsRequest{Subnet: Subnet}
-	jsonBody, err := json.Marshal(reqBody)
-	if err != nil {
-		log.Error("CMS : failed to marshal JSON: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to marshal JSON: %w", err)
-	}
-
-	req, err := http.NewRequest("POST", req_url, bytes.NewBuffer(jsonBody))
-	if err != nil {
-		log.Error("CMS : failed to NewRequest: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to create HTTP request: %w", err)
-	}
-
-	// Content-Type 헤더 설정
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	log.DebugInfo("Making request to: %s", req_url)
-	log.DebugInfo("Request body: %s", string(jsonBody))
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		log.Error("CMS : failed to send request: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to send request: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error("CMS : CMS returned status: %s", resp.Status)
-		return nil, fmt.Errorf("CMS server returned non-OK status: %s", resp.Status)
-	}
-	var addrResp CmsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
-		log.Error("CMS : failed to decode CMS response: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to decode response: %w", err)
-	}
-
-	return &addrResp, nil
-}
-
-func (c *CmsClient) AddCmsSubnet(ctx *vms.ControlContext, uuid vms.UUID) (*CmsResponse, error) {
+func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.CmsResponse, error) {
 	log := util.GetLogger()
 
 	ip, err := GetVMIPByUUID(ctx, uuid)
@@ -103,17 +22,16 @@ func (c *CmsClient) AddCmsSubnet(ctx *vms.ControlContext, uuid vms.UUID) (*CmsRe
 		log.Error("AddCmsSubnet : GetSubnetFromIP: %v", err)
 		return nil, fmt.Errorf("AddCmsSubnet: failed to get subnet: %w", err)
 	}
-	temp, err := c.CmsRequest(subnet)
+	resp, err := c.RequestSubnet(subnet)
 	if err != nil {
-		log.Error("AddCmsSubnet : c.CmsRequest(subnet): %v", err)
-		return nil, fmt.Errorf("AddCmsSubnet: CmsRequest failed: %w", err)
+		log.Error("AddCmsSubnet : RequestSubnet: %v", err)
+		return nil, fmt.Errorf("AddCmsSubnet: RequestSubnet failed: %w", err)
 	}
 
-	return temp, nil
-
+	return resp, nil
 }
 
-func (c *CmsClient) NewCmsSubnet(ctx *vms.ControlContext) (*CmsResponse, error) {
+func NewCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext) (*client.CmsResponse, error) {
 	log := util.GetLogger()
 
 	last_subnet := ctx.Last_subnet
@@ -129,19 +47,19 @@ func (c *CmsClient) NewCmsSubnet(ctx *vms.ControlContext) (*CmsResponse, error) 
 	}
 	ctx.Last_subnet = next_last_subnet
 
-	temp, err := c.CmsRequest(next_last_subnet)
+	resp, err := c.RequestSubnet(next_last_subnet)
 	if err != nil {
-		log.Error("NewCmsSubnet : c.CmsRequest(subnet): %v", err)
+		log.Error("NewCmsSubnet : RequestSubnet: %v", err)
 		// CMS 호출 실패 시 DB를 원래 값으로 롤백
 		if _, rbErr := ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", last_subnet); rbErr != nil {
 			log.Error("NewCmsSubnet : failed to rollback last_subnet: %v", rbErr)
-			return nil, fmt.Errorf("NewCmsSubnet: CmsRequest failed: %w, rollback also failed: %v", err, rbErr)
+			return nil, fmt.Errorf("NewCmsSubnet: RequestSubnet failed: %w, rollback also failed: %v", err, rbErr)
 		}
 		ctx.Last_subnet = last_subnet
-		return nil, fmt.Errorf("NewCmsSubnet: CmsRequest failed: %w", err)
+		return nil, fmt.Errorf("NewCmsSubnet: RequestSubnet failed: %w", err)
 	}
 
-	return temp, nil
+	return resp, nil
 }
 
 func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {
@@ -160,4 +78,3 @@ func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {
 
 	return vmInfo.IP_VM, nil
 }
-

--- a/service/vm.go
+++ b/service/vm.go
@@ -133,13 +133,13 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		}
 	}
 
-	var cmsResp *CmsResponse
-	cmsClient := NewCmsClient()
+	var cmsResp *client.CmsResponse
+	cmsClient := client.NewCmsClient()
 
 	if req.Subnettype == "Add" {
-		cmsResp, err = cmsClient.AddCmsSubnet(contextStruct, uuid)
+		cmsResp, err = AddCmsSubnet(cmsClient, contextStruct, uuid)
 	} else {
-		cmsResp, err = cmsClient.NewCmsSubnet(contextStruct)
+		cmsResp, err = NewCmsSubnet(cmsClient, contextStruct)
 		newSubnetAllocated = true
 	}
 	if err != nil {

--- a/service/vm.go
+++ b/service/vm.go
@@ -134,12 +134,12 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	}
 
 	var subnetReq *client.NewSubnetRequest
-	subnetClient := client.NewSubnetClient()
+	cmsClient := client.NewCmsClient()
 
 	if req.Subnettype == "Add" {
-		subnetReq, err = AddCmsSubnet(subnetClient, contextStruct, uuid)
+		subnetReq, err = AddCmsSubnet(cmsClient, contextStruct, uuid)
 	} else {
-		subnetReq, err = NewCmsSubnet(subnetClient, contextStruct)
+		subnetReq, err = NewCmsSubnet(cmsClient, contextStruct)
 		newSubnetAllocated = true
 	}
 	if err != nil {

--- a/service/vm.go
+++ b/service/vm.go
@@ -133,13 +133,13 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		}
 	}
 
-	var cmsResp *client.CmsResponse
-	cmsClient := client.NewCmsClient()
+	var subnetReq *client.NewSubnetRequest
+	subnetClient := client.NewSubnetClient()
 
 	if req.Subnettype == "Add" {
-		cmsResp, err = AddCmsSubnet(cmsClient, contextStruct, uuid)
+		subnetReq, err = AddCmsSubnet(subnetClient, contextStruct, uuid)
 	} else {
-		cmsResp, err = NewCmsSubnet(cmsClient, contextStruct)
+		subnetReq, err = NewCmsSubnet(subnetClient, contextStruct)
 		newSubnetAllocated = true
 	}
 	if err != nil {
@@ -147,11 +147,11 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		return fmt.Errorf("CreateVM: failed to configure cms: %w", err)
 	}
 
-	fmt.Printf("%s\n", cmsResp.IP)
-	fmt.Printf("%s\n", cmsResp.MacAddr)
-	fmt.Printf("%s\n", cmsResp.SdnUUID)
+	fmt.Printf("%s\n", subnetReq.IP)
+	fmt.Printf("%s\n", subnetReq.MacAddr)
+	fmt.Printf("%s\n", subnetReq.SdnUUID)
 
-	userPass := guacamole.Configure(req.Users[0].Name, string(req.UUID), cmsResp.IP, privateKeyPEM, contextStruct.GuacDB)
+	userPass := guacamole.Configure(req.Users[0].Name, string(req.UUID), subnetReq.IP, privateKeyPEM, contextStruct.GuacDB)
 
 	if userPass == "" {
 		log.Error("CreateVM: failed to configure Guacamole", true)
@@ -162,11 +162,11 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	newVM := &vms.VMInfo{
 		UUID:         uuid,
 		GuacPassword: userPass,
-		MacAddr:      cmsResp.MacAddr,
+		MacAddr:      subnetReq.MacAddr,
 		Memory:       req.HardwareInfo.Memory,
 		Cpu:          req.HardwareInfo.CPU,
 		Disk:         req.HardwareInfo.Disk,
-		IP_VM:        cmsResp.IP,
+		IP_VM:        subnetReq.IP,
 	}
 
 	// VMInfoIdx map 쓰기 + Free* 필드 감소는 원자적으로 처리해야 함
@@ -185,9 +185,9 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 
 	log.DebugInfo("core %s updated: FreeMemory=%d, FreeCPU=%d, FreeDisk=%d", selectedCore.IP, selectedCore.FreeMemory, selectedCore.FreeCPU, selectedCore.FreeDisk)
 
-	req.NetConf.Ips = []string{cmsResp.IP}
-	req.SdnUUID = cmsResp.SdnUUID
-	req.MacAddr = cmsResp.MacAddr
+	req.NetConf.Ips = []string{subnetReq.IP}
+	req.SdnUUID = subnetReq.SdnUUID
+	req.MacAddr = subnetReq.MacAddr
 	req.NetConf.NetType = 0
 	req.Users[0].SSHAuthorizedKeys = []string{publicKeyOpenSSH}
 
@@ -196,7 +196,7 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		CPU:    req.HardwareInfo.CPU,
 		Memory: req.HardwareInfo.Memory,
 		Disk:   req.HardwareInfo.Disk,
-		IP:     cmsResp.IP,
+		IP:     subnetReq.IP,
 		Status: model.VMStatusUnknown, // prepare begin 으로 초기화 함
 		Time:   time.Now().Unix(),
 	}
@@ -223,7 +223,7 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	}
 
 	if newSubnetAllocated {
-		_, err := contextStruct.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = '1'", cmsResp.IP)
+		_, err := contextStruct.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = '1'", subnetReq.IP)
 		if err != nil {
 			log.Error("Error database Subnet insertion failed: %v", err, true)
 		}


### PR DESCRIPTION
## Summary

- `service/network.go`에 섞여 있던 CMS HTTP 클라를 `client/cms.go`로 이동, `client`는 순수 통신, `service`는 비즈니스 로직만 담당하도록 하였습니다.
    - CmsClient
    - CmsRequest/Response
    - NewCmsClient
- `service/network.go`는 DB 선점/롤백/서브넷 계산 등 비즈니스 로직만 유지, `*client.CmsClient`를 인자로 받아 호출하도록 하였습니다.
    - AddCmsSubnet
    - NewCmsSubnet
    - GetVMIPByUUID
- 이때, type명 `CmsRequest`와 충돌 피하기 위해 메서드명 `CmsRequest` -> `RequestSubnet`으로 수정했습니다.

## Motivation

분리할 건 분리해야죠


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Docs / Config
- [ ] CI/CD

## Related Issue

#40 

## Testing

- [x] Tested locally
- [ ] No regression in existing functionality

## Checklist

- [ ] Reviewers assigned
- [ ] Related issue linked
