### PR TITLE
Refactor/infra separation

### DIFF
--- a/api/create_vm.go
+++ b/api/create_vm.go
@@ -5,16 +5,75 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/easy-cloud-Knet/KWS_Control/client/model"
 	"github.com/easy-cloud-Knet/KWS_Control/service"
+	"github.com/easy-cloud-Knet/KWS_Control/structure"
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
+
+// ApiCreateVmRequest for POST /vm HTTP Request Body contract.
+type ApiCreateVmRequest struct {
+	DomType    string          `json:"domType"`
+	DomName    string          `json:"domName"`
+	UUID       structure.UUID  `json:"uuid"`
+	OS         string          `json:"os"`
+	HWInfo     ApiHardwareInfo `json:"HWInfo"`
+	Network    ApiNetworkInfo  `json:"network"`
+	Users      []ApiUserInfo   `json:"users"`
+	SubnetType string          `json:"Subnettype"`
+}
+
+type ApiHardwareInfo struct {
+	CPU    uint32 `json:"cpu"`
+	Memory uint32 `json:"memory"` // MiB
+	Disk   uint32 `json:"disk"`   // MiB
+}
+
+type ApiNetworkInfo struct {
+	IPs []string `json:"ips"`
+	// NetType은 내부에서 0 고정 — API 클라이언트가 전송하더라도 무시됨
+}
+
+type ApiUserInfo struct {
+	Name              string   `json:"name"`
+	Groups            string   `json:"groups"`
+	Password          string   `json:"passWord"`
+	SSHAuthorizedKeys []string `json:"ssh"`
+}
+
+// ToServiceInput은 HTTP DTO를 서비스 계층 DTO로 변환
+func (r *ApiCreateVmRequest) ToServiceInput() service.CreateVMInput {
+	users := make([]service.UserSpec, len(r.Users))
+	for i, u := range r.Users {
+		users[i] = service.UserSpec{
+			Name:              u.Name,
+			Groups:            u.Groups,
+			Password:          u.Password,
+			SSHAuthorizedKeys: u.SSHAuthorizedKeys,
+		}
+	}
+	return service.CreateVMInput{
+		UUID:    r.UUID,
+		DomType: r.DomType,
+		DomName: r.DomName,
+		OS:      r.OS,
+		HardwareInfo: service.HardwareSpec{
+			CPU:    r.HWInfo.CPU,
+			Memory: r.HWInfo.Memory,
+			Disk:   r.HWInfo.Disk,
+		},
+		Network: service.NetworkSpec{
+			IPs: r.Network.IPs,
+		},
+		Users:      users,
+		SubnetType: r.SubnetType,
+	}
+}
 
 func (c *handlerContext) createVm(w http.ResponseWriter, r *http.Request) {
 	log := util.GetLogger()
 	defer r.Body.Close()
 
-	var req model.CreateVMRequest
+	var req ApiCreateVmRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		log.Error("createVm: failed to parse request body: %v", err, true)
 		var syntaxErr *json.SyntaxError
@@ -26,13 +85,12 @@ func (c *handlerContext) createVm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.HardwareInfo.Memory == 0 || req.HardwareInfo.CPU == 0 || req.HardwareInfo.Disk == 0 {
+	if req.HWInfo.Memory == 0 || req.HWInfo.CPU == 0 || req.HWInfo.Disk == 0 {
 		util.RespondError(w, http.StatusBadRequest, "Memory, CPU, and Disk must be non-zero")
 		return
 	}
 
-	err := service.CreateVM(req, c.context, c.rdb)
-	if err != nil {
+	if err := service.CreateVM(req.ToServiceInput(), c.context, c.rdb); err != nil {
 		log.Error("createVm: failed to create VM: %v", err, true)
 		util.RespondError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/api/get_vm_status.go
+++ b/api/get_vm_status.go
@@ -14,6 +14,26 @@ type ApiVmStatusRequest struct {
 	Type string         `json:"type"` // "cpu", "memory", or "disk"
 }
 
+type ApiVmCpuStatusResponse struct {
+	System float64 `json:"system_time"`
+	Idle   float64 `json:"idle_time"`
+	Usage  float64 `json:"usage_percent"`
+}
+
+type ApiVmMemoryStatusResponse struct {
+	Total       uint64  `json:"total_gb"`
+	Used        uint64  `json:"used_gb"`
+	Available   uint64  `json:"available_gb"`
+	UsedPercent float64 `json:"used_percent"`
+}
+
+type ApiVmDiskStatusResponse struct {
+	Total       uint64  `json:"total_gb"`
+	Used        uint64  `json:"used_gb"`
+	Free        uint64  `json:"free_gb"`
+	UsedPercent float64 `json:"used_percent"`
+}
+
 func (c *handlerContext) vmStatus(w http.ResponseWriter, r *http.Request) {
 	log := util.GetLogger()
 	defer r.Body.Close()
@@ -36,11 +56,14 @@ func (c *handlerContext) vmStatus(w http.ResponseWriter, r *http.Request) {
 
 	switch statusType {
 	case "cpu":
-		data, err = service.GetVMCpuInfo(req.UUID, c.context)
+		cpu, e := service.GetVMCpuInfo(req.UUID, c.context)
+		data, err = ApiVmCpuStatusResponse{System: cpu.System, Idle: cpu.Idle, Usage: cpu.Usage}, e
 	case "memory":
-		data, err = service.GetVMMemoryInfo(req.UUID, c.context)
+		mem, e := service.GetVMMemoryInfo(req.UUID, c.context)
+		data, err = ApiVmMemoryStatusResponse{Total: mem.Total, Used: mem.Used, Available: mem.Available, UsedPercent: mem.UsedPercent}, e
 	case "disk":
-		data, err = service.GetVMDiskInfo(req.UUID, c.context)
+		disk, e := service.GetVMDiskInfo(req.UUID, c.context)
+		data, err = ApiVmDiskStatusResponse{Total: disk.Total, Used: disk.Used, Free: disk.Free, UsedPercent: disk.UsedPercent}, e
 	}
 
 	if err != nil {

--- a/client/cms.go
+++ b/client/cms.go
@@ -18,7 +18,7 @@ type CmsClient struct {
 }
 
 type CmsNewInstanceResponse struct {
-	IP      string `json:"ip"`
+	IP      string `json:"IP"`
 	MacAddr string `json:"macAddr"`
 	SdnUUID string `json:"sdnUUID"`
 }
@@ -32,7 +32,7 @@ type cmsNewInstanceRequestBody struct {
 }
 
 type cmsDeleteInstanceRequestBody struct {
-	IP string `json:"ip"`
+	IP string `json:"IP"`
 }
 
 func NewCmsClient() *CmsClient {

--- a/client/cms.go
+++ b/client/cms.go
@@ -57,12 +57,12 @@ func (c *CmsClient) RequestDeleteInstance(ip string) (*CmsDeleteInstanceResponse
 	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
 	jsonBody, err := json.Marshal(cmsDeleteInstanceRequestBody{IP: ip})
 	if err != nil {
-		log.Error("CMS : failed to marshal JSON: %v", err)
+		log.Error("CmsClient.RequestDeleteInstance : failed to marshal JSON: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to marshal JSON: %w", err)
 	}
 	req, err := http.NewRequest("DELETE", reqURL, bytes.NewBuffer(jsonBody))
 	if err != nil {
-		log.Error("CMS : failed to NewRequest: %v", err)
+		log.Error("CmsClient.RequestDeleteInstance : failed to NewRequest: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to create HTTP request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -73,19 +73,19 @@ func (c *CmsClient) RequestDeleteInstance(ip string) (*CmsDeleteInstanceResponse
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		log.Error("CMS : failed to send request: %v", err)
+		log.Error("CmsClient.RequestDeleteInstance : failed to send request: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Error("CMS : CMS returned status: %s", resp.Status)
+		log.Error("CmsClient.RequestDeleteInstance : CMS returned status: %s", resp.Status)
 		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: CMS server returned non-OK status: %s", resp.Status)
 	}
 
 	var addrResp CmsDeleteInstanceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
-		log.Error("CMS : failed to decode CMS response: %v", err)
+		log.Error("CmsClient.RequestDeleteInstance : failed to decode CMS response: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to decode response: %w", err)
 	}
 	return &addrResp, nil
@@ -98,13 +98,13 @@ func (c *CmsClient) RequestNewInstance(subnet string) (*CmsNewInstanceResponse, 
 	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
 	jsonBody, err := json.Marshal(cmsNewInstanceRequestBody{Subnet: subnet})
 	if err != nil {
-		log.Error("CMS : failed to marshal JSON: %v", err)
+		log.Error("CmsClient.RequestNewInstance : failed to marshal JSON: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to marshal JSON: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", reqURL, bytes.NewBuffer(jsonBody))
 	if err != nil {
-		log.Error("CMS : failed to NewRequest: %v", err)
+		log.Error("CmsClient.RequestNewInstance : failed to NewRequest: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to create HTTP request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -115,19 +115,19 @@ func (c *CmsClient) RequestNewInstance(subnet string) (*CmsNewInstanceResponse, 
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		log.Error("CMS : failed to send request: %v", err)
+		log.Error("CmsClient.RequestNewInstance : failed to send request: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Error("CMS : CMS returned status: %s", resp.Status)
+		log.Error("CmsClient.RequestNewInstance : CMS returned status: %s", resp.Status)
 		return nil, fmt.Errorf("CmsClient.RequestNewInstance: CMS server returned non-OK status: %s", resp.Status)
 	}
 
 	var addrResp CmsNewInstanceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
-		log.Error("CMS : failed to decode CMS response: %v", err)
+		log.Error("CmsClient.RequestNewInstance : failed to decode CMS response: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to decode response: %w", err)
 	}
 	return &addrResp, nil

--- a/client/cms.go
+++ b/client/cms.go
@@ -1,0 +1,86 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/easy-cloud-Knet/KWS_Control/util"
+)
+
+// CmsClient는 CMS서비스에 서브넷/인스턴스 생성을 요청하는 HTTP 클라이언트.
+type CmsClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+type CmsResponse struct {
+	IP      string `json:"ip"`
+	MacAddr string `json:"macAddr"`
+	SdnUUID string `json:"sdnUUID"`
+}
+
+type cmsRequestBody struct {
+	Subnet string `json:"Subnet"`
+}
+
+func NewCmsClient() *CmsClient {
+	host := os.Getenv("CMS_HOST")
+	if host == "" {
+		log := util.GetLogger()
+		log.Error("CMS_HOST Re:Check your env variable", true)
+		host = "localhost:8080"
+		log.Warn("CMS_HOST set: %s", host, true)
+	}
+	return &CmsClient{
+		baseURL: host,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// RequestNewInstance는 주어진 서브넷에 대해 CMS에 새 인스턴스 할당을 요청한다.
+func (c *CmsClient) RequestNewInstance(subnet string) (*CmsResponse, error) {
+	log := util.GetLogger()
+
+	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
+	jsonBody, err := json.Marshal(cmsRequestBody{Subnet: subnet})
+	if err != nil {
+		log.Error("CMS : failed to marshal JSON: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to marshal JSON: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", reqURL, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		log.Error("CMS : failed to NewRequest: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	log.DebugInfo("Making request to: %s", reqURL)
+	log.DebugInfo("Request body: %s", string(jsonBody))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Error("CMS : failed to send request: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Error("CMS : CMS returned status: %s", resp.Status)
+		return nil, fmt.Errorf("CMS server returned non-OK status: %s", resp.Status)
+	}
+
+	var addrResp CmsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
+		log.Error("CMS : failed to decode CMS response: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to decode response: %w", err)
+	}
+	return &addrResp, nil
+}

--- a/client/cms.go
+++ b/client/cms.go
@@ -17,14 +17,22 @@ type CmsClient struct {
 	client  *http.Client
 }
 
-type CmsResponse struct {
+type CmsNewInstanceResponse struct {
 	IP      string `json:"ip"`
 	MacAddr string `json:"macAddr"`
 	SdnUUID string `json:"sdnUUID"`
 }
 
-type cmsRequestBody struct {
+type CmsDeleteInstanceResponse struct {
+	Detail string `json:"detail,omitempty"`
+}
+
+type cmsNewInstanceRequestBody struct {
 	Subnet string `json:"Subnet"`
+}
+
+type cmsDeleteInstanceRequestBody struct {
+	IP string `json:"ip"`
 }
 
 func NewCmsClient() *CmsClient {
@@ -43,12 +51,52 @@ func NewCmsClient() *CmsClient {
 	}
 }
 
-// RequestNewInstance는 주어진 서브넷에 대해 CMS에 새 인스턴스 할당을 요청한다.
-func (c *CmsClient) RequestNewInstance(subnet string) (*CmsResponse, error) {
+func (c *CmsClient) RequestDeleteInstance(ip string) (*CmsDeleteInstanceResponse, error) {
 	log := util.GetLogger()
 
 	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
-	jsonBody, err := json.Marshal(cmsRequestBody{Subnet: subnet})
+	jsonBody, err := json.Marshal(cmsDeleteInstanceRequestBody{IP: ip})
+	if err != nil {
+		log.Error("CMS : failed to marshal JSON: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to marshal JSON: %w", err)
+	}
+	req, err := http.NewRequest("DELETE", reqURL, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		log.Error("CMS : failed to NewRequest: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	log.DebugInfo("Making request to: %s", reqURL)
+	log.DebugInfo("Request body: %s", string(jsonBody))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Error("CMS : failed to send request: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Error("CMS : CMS returned status: %s", resp.Status)
+		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: CMS server returned non-OK status: %s", resp.Status)
+	}
+
+	var addrResp CmsDeleteInstanceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
+		log.Error("CMS : failed to decode CMS response: %v", err)
+		return nil, fmt.Errorf("CmsClient.RequestDeleteInstance: failed to decode response: %w", err)
+	}
+	return &addrResp, nil
+}
+
+// RequestNewInstance는 주어진 서브넷에 대해 CMS에 새 인스턴스 할당을 요청한다.
+func (c *CmsClient) RequestNewInstance(subnet string) (*CmsNewInstanceResponse, error) {
+	log := util.GetLogger()
+
+	reqURL := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
+	jsonBody, err := json.Marshal(cmsNewInstanceRequestBody{Subnet: subnet})
 	if err != nil {
 		log.Error("CMS : failed to marshal JSON: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to marshal JSON: %w", err)
@@ -74,10 +122,10 @@ func (c *CmsClient) RequestNewInstance(subnet string) (*CmsResponse, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Error("CMS : CMS returned status: %s", resp.Status)
-		return nil, fmt.Errorf("CMS server returned non-OK status: %s", resp.Status)
+		return nil, fmt.Errorf("CmsClient.RequestNewInstance: CMS server returned non-OK status: %s", resp.Status)
 	}
 
-	var addrResp CmsResponse
+	var addrResp CmsNewInstanceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
 		log.Error("CMS : failed to decode CMS response: %v", err)
 		return nil, fmt.Errorf("CmsClient.RequestNewInstance: failed to decode response: %w", err)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.Error("Failed to initialize: %v", err, true)
 		panic(err)
 	}
-	printCores(contextStruct.Cores)
+	printCores(contextStruct.Resources.Cores)
 
 	go func() {
 		err := api.Server(contextStruct.Config.Port, &contextStruct, rdb)

--- a/service/cleanup.go
+++ b/service/cleanup.go
@@ -1,0 +1,20 @@
+package service
+
+// cleanupChain will execute registered cleanup functions in reverse order when run() is called.
+// cleanup chain will register cleanup functions for each step of the process,
+// so that if any step fails, all previous steps can be undone to maintain system consistency.
+type cleanupChain struct {
+	steps []func()
+}
+
+func (c *cleanupChain) push(fn func()) {
+	c.steps = append(c.steps, fn)
+}
+
+func (c *cleanupChain) run() {
+	for i := len(c.steps) - 1; i >= 0; i-- {
+		c.steps[i]()
+	}
+	//for Idempotency
+	c.steps = nil
+}

--- a/service/dto.go
+++ b/service/dto.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	vms "github.com/easy-cloud-Knet/KWS_Control/structure"
+)
+
+// Service Layer DTO.
+// DTOs for service layer to decouple API layer from internal implementation details.
+// API Handler will convert API layer DTOs to service layer DTOs.
+// Service layer will convert to internal client/model structures as needed.
+//
+
+type CreateVMInput struct {
+	UUID         vms.UUID
+	DomType      string
+	DomName      string
+	OS           string
+	HardwareInfo HardwareSpec
+	Network      NetworkSpec
+	Users        []UserSpec
+	SubnetType   string // "Add" 또는 그 외(=신규 서브넷)
+}
+
+type HardwareSpec struct {
+	CPU    uint32
+	Memory uint32 // MiB
+	Disk   uint32 // MiB
+}
+
+type NetworkSpec struct {
+	IPs []string
+}
+
+type UserSpec struct {
+	Name              string
+	Groups            string
+	Password          string
+	SSHAuthorizedKeys []string
+}
+
+// Output DTOs
+type VMInfo struct {
+	UUID   vms.UUID
+	CPU    uint32
+	Memory uint32 // MiB
+	Disk   uint32 // MiB
+	IP     string
+	Status string
+}
+
+type VMCpuStatus struct {
+	System float64
+	Idle   float64
+	Usage  float64
+}
+
+type VMMemoryStatus struct {
+	Total       uint64
+	Used        uint64
+	Available   uint64
+	UsedPercent float64
+}
+
+type VMDiskStatus struct {
+	Total       uint64
+	Used        uint64
+	Free        uint64
+	UsedPercent float64
+}

--- a/service/guacamole.go
+++ b/service/guacamole.go
@@ -14,9 +14,9 @@ func GetGuacamoleToken(uuid structure.UUID, ctx *structure.ControlContext) (stri
 		return "", structure.ErrCoreNotFound(uuid)
 	}
 
-	ctx.RLock()
+	ctx.Resources.RLock()
 	vm, exists := core.VMInfoIdx[uuid]
-	ctx.RUnlock()
+	ctx.Resources.RUnlock()
 
 	if exists {
 		guacClient := client.NewGuacamoleClient(&ctx.Config)

--- a/service/network.go
+++ b/service/network.go
@@ -145,10 +145,10 @@ func (c *CmsClient) NewCmsSubnet(ctx *vms.ControlContext) (*CmsResponse, error) 
 }
 
 func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {
-	ctx.RLock()
-	defer ctx.RUnlock()
+	ctx.Resources.RLock()
+	defer ctx.Resources.RUnlock()
 
-	core, ok := ctx.VMLocation[uuid]
+	core, ok := ctx.Resources.VMLocation[uuid]
 	if !ok {
 		return "", fmt.Errorf("UUID %s not found in VMLocation", uuid)
 	}

--- a/service/network.go
+++ b/service/network.go
@@ -10,7 +10,7 @@ import (
 )
 
 // AddCmsSubnet은 기존 VM의 IP가 속한 서브넷으로 CMS에 새 인스턴스 할당을 요청
-func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.CmsResponse, error) {
+func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.CmsNewInstanceResponse, error) {
 	log := util.GetLogger()
 
 	ip, err := GetVMIPByUUID(ctx, uuid)
@@ -32,7 +32,7 @@ func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (
 }
 
 // NewCmsSubnet은 다음 서브넷을 계산하여 DB에 선점한 뒤 CMS에 인스턴스 할당을 요청
-func NewCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext) (*client.CmsResponse, error) {
+func NewCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext) (*client.CmsNewInstanceResponse, error) {
 	log := util.GetLogger()
 
 	lastSubnet := ctx.Last_subnet
@@ -59,6 +59,21 @@ func NewCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext) (*client.CmsResp
 		return nil, fmt.Errorf("NewCmsSubnet: CMS request failed: %w", err)
 	}
 	return resp, nil
+}
+func DeleteCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) error {
+	log := util.GetLogger()
+
+	ip, err := GetVMIPByUUID(ctx, uuid)
+	if err != nil {
+		log.Error("DeleteCmsSubnet : GetVMIPByUUID: %v", err)
+		return fmt.Errorf("DeleteCmsSubnet: failed to get VM IP: %w", err)
+	}
+	_, err = c.RequestDeleteInstance(ip)
+	if err != nil {
+		log.Error("DeleteCmsSubnet : RequestDeleteInstance: %v", err)
+		return fmt.Errorf("DeleteCmsSubnet: CMS request failed: %w", err)
+	}
+	return nil
 }
 
 func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {

--- a/service/network.go
+++ b/service/network.go
@@ -1,96 +1,16 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
-	"time"
 
+	"github.com/easy-cloud-Knet/KWS_Control/client"
 	pkgnetwork "github.com/easy-cloud-Knet/KWS_Control/pkg/network"
 	vms "github.com/easy-cloud-Knet/KWS_Control/structure"
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
-type CmsClient struct {
-	baseURL string
-	client  *http.Client
-}
-
-type CmsResponse struct {
-	IP      string `json:"ip"`
-	MacAddr string `json:"macAddr"`
-	SdnUUID string `json:"sdnUUID"`
-}
-
-type CmsRequest struct {
-	Subnet string `json:"Subnet"`
-}
-
-// fmt.Sprintf("%s/New/Instance", CMS_HOST)
-func NewCmsClient() *CmsClient {
-	CMS_HOST := os.Getenv("CMS_HOST")
-	if CMS_HOST == "" {
-		log := util.GetLogger()
-		log.Error("CMS_HOST Re:Check your env variable", true)
-		CMS_HOST = "localhost:8080"
-		log.Warn("CMS_HOST set: %s", CMS_HOST, true)
-	}
-	return &CmsClient{
-		baseURL: CMS_HOST,
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-	}
-}
-
-func (c *CmsClient) CmsRequest(Subnet string) (*CmsResponse, error) {
-	log := util.GetLogger()
-
-	req_url := fmt.Sprintf("http://%s/New/Instance", c.baseURL)
-	reqBody := CmsRequest{Subnet: Subnet}
-	jsonBody, err := json.Marshal(reqBody)
-	if err != nil {
-		log.Error("CMS : failed to marshal JSON: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to marshal JSON: %w", err)
-	}
-
-	req, err := http.NewRequest("POST", req_url, bytes.NewBuffer(jsonBody))
-	if err != nil {
-		log.Error("CMS : failed to NewRequest: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to create HTTP request: %w", err)
-	}
-
-	// Content-Type 헤더 설정
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	log.DebugInfo("Making request to: %s", req_url)
-	log.DebugInfo("Request body: %s", string(jsonBody))
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		log.Error("CMS : failed to send request: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to send request: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error("CMS : CMS returned status: %s", resp.Status)
-		return nil, fmt.Errorf("CMS server returned non-OK status: %s", resp.Status)
-	}
-	var addrResp CmsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&addrResp); err != nil {
-		log.Error("CMS : failed to decode CMS response: %v", err)
-		return nil, fmt.Errorf("CmsRequest: failed to decode response: %w", err)
-	}
-
-	return &addrResp, nil
-}
-
-func (c *CmsClient) AddCmsSubnet(ctx *vms.ControlContext, uuid vms.UUID) (*CmsResponse, error) {
+// AddCmsSubnet은 기존 VM의 IP가 속한 서브넷으로 CMS에 새 인스턴스 할당을 요청
+func AddCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext, uuid vms.UUID) (*client.CmsResponse, error) {
 	log := util.GetLogger()
 
 	ip, err := GetVMIPByUUID(ctx, uuid)
@@ -103,45 +23,42 @@ func (c *CmsClient) AddCmsSubnet(ctx *vms.ControlContext, uuid vms.UUID) (*CmsRe
 		log.Error("AddCmsSubnet : GetSubnetFromIP: %v", err)
 		return nil, fmt.Errorf("AddCmsSubnet: failed to get subnet: %w", err)
 	}
-	temp, err := c.CmsRequest(subnet)
+	resp, err := c.RequestNewInstance(subnet)
 	if err != nil {
-		log.Error("AddCmsSubnet : c.CmsRequest(subnet): %v", err)
-		return nil, fmt.Errorf("AddCmsSubnet: CmsRequest failed: %w", err)
+		log.Error("AddCmsSubnet : RequestNewInstance: %v", err)
+		return nil, fmt.Errorf("AddCmsSubnet: CMS request failed: %w", err)
 	}
-
-	return temp, nil
-
+	return resp, nil
 }
 
-func (c *CmsClient) NewCmsSubnet(ctx *vms.ControlContext) (*CmsResponse, error) {
+// NewCmsSubnet은 다음 서브넷을 계산하여 DB에 선점한 뒤 CMS에 인스턴스 할당을 요청
+func NewCmsSubnet(c *client.CmsClient, ctx *vms.ControlContext) (*client.CmsResponse, error) {
 	log := util.GetLogger()
 
-	last_subnet := ctx.Last_subnet
-	next_last_subnet := pkgnetwork.FindSubnet(last_subnet)
-	log.Info("NewCmsSubnet : next_last_subnet: %s", next_last_subnet)
+	lastSubnet := ctx.Last_subnet
+	nextLastSubnet := pkgnetwork.FindSubnet(lastSubnet)
+	log.Info("NewCmsSubnet : next_last_subnet: %s", nextLastSubnet)
 
-	// DB를 먼저 업데이트하여 서브넷을 선점한다.
-	// CMS 호출 전에 선점해야 실패 시 동일 서브넷이 중복 할당되는 것을 방지할 수 있다.
-	_, err := ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", next_last_subnet)
+	//CMS 호출 전에 다음 서브넷을 선점하여 동시 호출 시 중복 할당 방지
+	_, err := ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", nextLastSubnet)
 	if err != nil {
 		log.Error("Failed to update last_subnet in database: %v", err)
 		return nil, fmt.Errorf("NewCmsSubnet: failed to update last_subnet in DB: %w", err)
 	}
-	ctx.Last_subnet = next_last_subnet
+	ctx.Last_subnet = nextLastSubnet
 
-	temp, err := c.CmsRequest(next_last_subnet)
+	resp, err := c.RequestNewInstance(nextLastSubnet)
 	if err != nil {
-		log.Error("NewCmsSubnet : c.CmsRequest(subnet): %v", err)
+		log.Error("NewCmsSubnet : RequestNewInstance: %v", err)
 		// CMS 호출 실패 시 DB를 원래 값으로 롤백
-		if _, rbErr := ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", last_subnet); rbErr != nil {
+		if _, rbErr := ctx.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = 1", lastSubnet); rbErr != nil {
 			log.Error("NewCmsSubnet : failed to rollback last_subnet: %v", rbErr)
-			return nil, fmt.Errorf("NewCmsSubnet: CmsRequest failed: %w, rollback also failed: %v", err, rbErr)
+			return nil, fmt.Errorf("NewCmsSubnet: CMS request failed: %w, rollback also failed: %v", err, rbErr)
 		}
-		ctx.Last_subnet = last_subnet
-		return nil, fmt.Errorf("NewCmsSubnet: CmsRequest failed: %w", err)
+		ctx.Last_subnet = lastSubnet
+		return nil, fmt.Errorf("NewCmsSubnet: CMS request failed: %w", err)
 	}
-
-	return temp, nil
+	return resp, nil
 }
 
 func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {
@@ -160,4 +77,3 @@ func GetVMIPByUUID(ctx *vms.ControlContext, uuid vms.UUID) (string, error) {
 
 	return vmInfo.IP_VM, nil
 }
-

--- a/service/redis.go
+++ b/service/redis.go
@@ -11,12 +11,46 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-func StoreVMInfoToRedis(ctx context.Context, rdb *redis.Client, vmInfo model.VMRedisInfo) error {
+// redisVMInfo is the internal structure for storing instance info in Redis.
+// For Separation of Concerns, this is not exposed outside the service layer.
+// service DTOs are converted to/from this format for Redis operations.
+type redisVMInfo struct {
+	UUID   structure.UUID `json:"uuid"`
+	CPU    uint32         `json:"cpu"`
+	Memory uint32         `json:"memory"` // MiB
+	Disk   uint32         `json:"disk"`   // MiB
+	IP     string         `json:"ip"`
+	Status string         `json:"status"`
+	Time   int64          `json:"time"`
+}
+
+func (r redisVMInfo) toServiceDTO() VMInfo {
+	return VMInfo{
+		UUID:   r.UUID,
+		CPU:    r.CPU,
+		Memory: r.Memory,
+		Disk:   r.Disk,
+		IP:     r.IP,
+		Status: r.Status,
+	}
+}
+
+// StoreVMInfoToRedis will serialize the given VMInfo and store it in Redis under the key of its UUID.
+func StoreVMInfoToRedis(ctx context.Context, rdb *redis.Client, vmInfo VMInfo, timestamp int64) error {
 	log := util.GetLogger()
 
 	key := string(vmInfo.UUID)
+	stored := redisVMInfo{
+		UUID:   vmInfo.UUID,
+		CPU:    vmInfo.CPU,
+		Memory: vmInfo.Memory,
+		Disk:   vmInfo.Disk,
+		IP:     vmInfo.IP,
+		Status: vmInfo.Status,
+		Time:   timestamp,
+	}
 
-	jsonData, err := json.Marshal(vmInfo)
+	jsonData, err := json.Marshal(stored)
 	if err != nil {
 		log.Error("failed to marshal vm for redis %v", err, true)
 		return fmt.Errorf("failed to marshal vm for redis: %w", err)
@@ -28,8 +62,7 @@ func StoreVMInfoToRedis(ctx context.Context, rdb *redis.Client, vmInfo model.VMR
 	}
 
 	log.Info("vm info stored in redis: UUID=%s, CPU=%d, Memory=%d, Disk=%d, IP=%s, Status=%s, Time=%d",
-		key, vmInfo.CPU, vmInfo.Memory, vmInfo.Disk, vmInfo.IP, vmInfo.Status, vmInfo.Time, true)
-
+		key, stored.CPU, stored.Memory, stored.Disk, stored.IP, stored.Status, stored.Time, true)
 	return nil
 }
 
@@ -37,7 +70,6 @@ func RemoveVMInfoFromRedis(ctx context.Context, rdb *redis.Client, uuid structur
 	log := util.GetLogger()
 
 	key := string(uuid)
-
 	result, err := rdb.Del(ctx, key).Result()
 	if err != nil {
 		log.Error("failed to delete vm from redis: UUID=%s, error=%v", key, err, true)
@@ -49,51 +81,60 @@ func RemoveVMInfoFromRedis(ctx context.Context, rdb *redis.Client, uuid structur
 	} else {
 		log.Info("vm info removed from redis: UUID=%s", key, true)
 	}
-
 	return nil
 }
 
-func GetVMInfoFromRedis(ctx context.Context, rdb *redis.Client, uuid structure.UUID) (model.VMRedisInfo, error) {
+// GetVMInfoFromRedis는 service DTO를 반환
+func GetVMInfoFromRedis(ctx context.Context, rdb *redis.Client, uuid structure.UUID) (VMInfo, error) {
+	log := util.GetLogger()
+
+	stored, err := loadRedisVMInfo(ctx, rdb, uuid)
+	if err != nil {
+		return VMInfo{}, err
+	}
+	log.DebugInfo("vm info retrieved from redis: UUID=%s", string(uuid))
+	return stored.toServiceDTO(), nil
+}
+
+// loadRedisVMInfo는 Redis에서 raw 저장 포맷을 읽음 (service 계층)
+// UpdateVMStatusInRedis에서의 Time 필드 보존을 위해 필요
+func loadRedisVMInfo(ctx context.Context, rdb *redis.Client, uuid structure.UUID) (redisVMInfo, error) {
 	log := util.GetLogger()
 
 	key := string(uuid)
-	var vmInfo model.VMRedisInfo
+	var stored redisVMInfo
 
 	jsonData, err := rdb.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
 			log.Warn("vm info not found in redis: UUID=%s", key, true)
-			return vmInfo, fmt.Errorf("vm info not found in redis: %s", key)
+			return stored, fmt.Errorf("vm info not found in redis: %s", key)
 		}
 		log.Error("failed to get vm from redis: UUID=%s, error=%v", key, err, true)
-		return vmInfo, fmt.Errorf("failed to get vm from redis: %w", err)
+		return stored, fmt.Errorf("failed to get vm from redis: %w", err)
 	}
 
-	if err := json.Unmarshal([]byte(jsonData), &vmInfo); err != nil {
+	if err := json.Unmarshal([]byte(jsonData), &stored); err != nil {
 		log.Error("failed to unmarshal vm from redis: UUID=%s, error=%v", key, err, true)
-		return vmInfo, fmt.Errorf("failed to unmarshal vm from redis: %w", err)
+		return stored, fmt.Errorf("failed to unmarshal vm from redis: %w", err)
 	}
-
-	log.DebugInfo("vm info retrieved from redis: UUID=%s", key)
-	return vmInfo, nil
+	return stored, nil
 }
 
-// VM status랑 time 한 번에 업뎃.. 통합 필요
 func UpdateVMStatusInRedis(ctx context.Context, rdb *redis.Client, uuid structure.UUID, status string, timestamp int64) error {
 	log := util.GetLogger()
 
 	key := string(uuid)
-
-	vmInfo, err := GetVMInfoFromRedis(ctx, rdb, uuid)
+	stored, err := loadRedisVMInfo(ctx, rdb, uuid)
 	if err != nil {
 		log.Error("failed to get existing vm info from redis: UUID=%s, error=%v", key, err, true)
 		return fmt.Errorf("failed to get existing vm info from redis: %w", err)
 	}
 
-	vmInfo.Status = status
-	vmInfo.Time = timestamp
+	stored.Status = status
+	stored.Time = timestamp
 
-	jsonData, err := json.Marshal(vmInfo)
+	jsonData, err := json.Marshal(stored)
 	if err != nil {
 		log.Error("failed to marshal updated vm for redis: UUID=%s, error=%v", key, err, true)
 		return fmt.Errorf("failed to marshal updated vm for redis: %w", err)
@@ -107,3 +148,15 @@ func UpdateVMStatusInRedis(ctx context.Context, rdb *redis.Client, uuid structur
 	log.Info("vm status updated in redis: UUID=%s, Status=%s, Time=%d", key, status, timestamp, true)
 	return nil
 }
+
+// VM 상태 상수는 client/model에서 재노출 (api/update_redis.go도 동일 상수 정의, 추후 통합 예정)
+const (
+	VMStatusPrepareBegin = model.VMStatusPrepareBegin
+	VMStatusStartBegin   = model.VMStatusStartBegin
+	VMStatusStarted      = model.VMStatusStarted
+	VMStatusStopped      = model.VMStatusStopped
+	VMStatusRelease      = model.VMStatusRelease
+	VMStatusMigrate      = model.VMStatusMigrate
+	VMStatusRestore      = model.VMStatusRestore
+	VMStatusUnknown      = model.VMStatusUnknown
+)

--- a/service/vm.go
+++ b/service/vm.go
@@ -42,23 +42,28 @@ func CreateVM(input CreateVMInput, contextStruct *vms.ControlContext, rdb *redis
 	// 단계별 롤백 등록을 위한 chain
 	cleanup := &cleanupChain{}
 
+	//사용자 수 확인
+	if len(input.Users) == 0 {
+		cleanup.run()
+		log.Error("CreateVM: at least one user is required for Guacamole configuration", true)
+		return fmt.Errorf("CreateVM: at least one user is required")
+	}
+
 	// 3) CMS 서브넷 할당 (Add: 기존 서브넷 / New: 신규 서브넷)
-	cmsResp, isNewSubnet, err := allocateCmsSubnet(contextStruct, input.SubnetType, uuid, cleanup)
+	cmsResp, isNewSubnet, err := allocateCmsSubnet(contextStruct, input.SubnetType, uuid)
 	if err != nil {
-		return err
+		//TODO  AllocateCmsSubnet cleanup logic implement
+		log.Error("CreateVM: failed to allocate CMS subnet: %v", err, true)
+		return fmt.Errorf("CreateVM: failed to allocate CMS subnet: %w", err)
 	}
 
 	log.DebugInfo("CMS allocated: ip=%s, mac=%s, sdn=%s", cmsResp.IP, cmsResp.MacAddr, cmsResp.SdnUUID)
 
 	// 4) Guacamole 사용자/커넥션 설정
-	if len(input.Users) == 0 {
-		cleanup.run()
-		return fmt.Errorf("CreateVM: at least one user is required")
-	}
 	userPass := guacamole.Configure(input.Users[0].Name, string(uuid), cmsResp.IP, privateKeyPEM, contextStruct.GuacDB)
 	if userPass == "" {
-		log.Error("CreateVM: failed to configure Guacamole", true)
 		cleanup.run()
+		log.Error("CreateVM: failed to configure Guacamole", true)
 		return fmt.Errorf("CreateVM: failed to configure Guacamole")
 	}
 	cleanup.push(func() {
@@ -131,7 +136,7 @@ func CreateVM(input CreateVMInput, contextStruct *vms.ControlContext, rdb *redis
 }
 
 // 추후 Mapper 계층이 필요할 것으로 예상됨
-func buildCoreCreateVMRequest(input CreateVMInput, cmsResp *client.CmsResponse, publicKeyOpenSSH string) model.CreateVMRequest {
+func buildCoreCreateVMRequest(input CreateVMInput, cmsResp *client.CmsNewInstanceResponse, publicKeyOpenSSH string) model.CreateVMRequest {
 	users := make([]model.UserInfoVM, len(input.Users))
 	for i, u := range input.Users {
 		users[i] = model.UserInfoVM{
@@ -194,7 +199,7 @@ func selectCoreOrFail(contextStruct *vms.ControlContext, req vms.HardwareRequire
 	return nil, -1, fmt.Errorf("CreateVM: no suitable core found")
 }
 
-func allocateCmsSubnet(contextStruct *vms.ControlContext, subnetType string, uuid vms.UUID, cleanup *cleanupChain) (*client.CmsResponse, bool, error) {
+func allocateCmsSubnet(contextStruct *vms.ControlContext, subnetType string, uuid vms.UUID) (*client.CmsNewInstanceResponse, bool, error) {
 	log := util.GetLogger()
 	cmsClient := client.NewCmsClient()
 
@@ -213,9 +218,7 @@ func allocateCmsSubnet(contextStruct *vms.ControlContext, subnetType string, uui
 		return nil, false, fmt.Errorf("CreateVM: failed to configure cms: %w", err)
 	}
 	// 신규 서브넷 할당 시: 후속 단계 실패에 대한 별도 DB 롤백 로직은 미구현 상태 (TODO)
-	cleanup.push(func() {
-		log.Warn("clean up: new subnet allocation rollback is not implemented")
-	})
+
 	return resp, true, nil
 }
 
@@ -236,6 +239,12 @@ func DeleteVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Clien
 	}); err != nil {
 		log.Error("error deleting VM %s on core %s: %v", uuid, core.IP, err)
 		return fmt.Errorf("DeleteVM: failed to delete VM %s on core %s: %w", uuid, core.IP, err)
+	}
+
+	cmsClient := client.NewCmsClient()
+	if err := DeleteCmsSubnet(cmsClient, contextStruct, uuid); err != nil {
+		log.Error("DeleteVM: failed to delete CMS subnet for VM %s: %v", uuid, err)
+		// CMS 삭제 실패는 로그만 남기고 삭제 자체는 성공으로 처리 (추가적인 수동 정리 필요)
 	}
 
 	// 2) DB에서 인스턴스 정보 삭제

--- a/service/vm.go
+++ b/service/vm.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/easy-cloud-Knet/KWS_Control/client"
@@ -16,266 +15,248 @@ import (
 	vms "github.com/easy-cloud-Knet/KWS_Control/structure"
 )
 
-// 새 VM 만드는 무언가.
-// 자원 많이 남은 코어를 찾고, 리소스 할당 업데이트, ControlContext 상태 업데이트.
-func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb *redis.Client) error {
+func CreateVM(input CreateVMInput, contextStruct *vms.ControlContext, rdb *redis.Client) error {
 	log := util.GetLogger()
-
-	log.Info("func CreateVM() memory=%d GiB, cpu=%d, disk=%d GiB", req.HardwareInfo.Memory, req.HardwareInfo.CPU, req.HardwareInfo.Disk, true)
-
-	// err = validateCreateVMRequest(req)
-
-	// guacamole 부분 필요
-
-	// 적합한 코어 찾기
-	log.DebugInfo("core selection process. req: memory=%d GiB, cpu=%d, disk=%d",
-		req.HardwareInfo.Memory, req.HardwareInfo.CPU, req.HardwareInfo.Disk)
-
-	var selectedCore *vms.Core = nil
-	selectedCoreIndex := -1
-	aliveCount := 0
-
-	// Cores/FreeMemory 등 공유 상태를 읽으므로 RLock (동시 읽기는 허용, 쓰기만 차단)
-	contextStruct.Resources.RLock()
-	for i := range contextStruct.Resources.Cores {
-
-		core := &contextStruct.Resources.Cores[i]
-		log.DebugInfo("core %s checking: FreeMemory=%d, FreeCPU=%d, FreeDisk=%d, IsAlive=%t", core.IP, core.FreeMemory, core.FreeCPU, core.FreeDisk, core.IsAlive)
-
-		if !core.IsAlive {
-			log.DebugWarn("core %s is not alive, skipping", core.IP)
-			continue
-		}
-		aliveCount++
-
-		memoryOk := core.FreeMemory >= req.HardwareInfo.Memory
-		cpuOk := core.FreeCPU >= req.HardwareInfo.CPU
-		diskOk := core.FreeDisk >= req.HardwareInfo.Disk
-
-		if req.HardwareInfo.Disk == 0 {
-			log.DebugError("test")
-		}
-
-		if !memoryOk {
-			log.DebugWarn("%s !memoryOk: req=%d, available=%d", core.IP, req.HardwareInfo.Memory, core.FreeMemory)
-		}
-		if !cpuOk {
-			log.DebugWarn("%s !cpuOk   : req=%d, available=%d", core.IP, req.HardwareInfo.CPU, core.FreeCPU)
-		}
-		if !diskOk {
-			log.DebugWarn("%s !diskOk  : req=%d, available=%d", core.IP, req.HardwareInfo.Disk, core.FreeDisk)
-		}
-
-		if memoryOk && cpuOk && diskOk {
-			selectedCore = core
-			selectedCoreIndex = i
-			log.DebugInfo("core found: %s", selectedCore.IP)
-			break
-		} else {
-			log.DebugInfo("%s rejected: memory=%t, cpu=%t, disk=%t", core.IP, memoryOk, cpuOk, diskOk)
-		}
+	uuid := input.UUID
+	hwReq := vms.HardwareRequirement{
+		Memory: input.HardwareInfo.Memory,
+		CPU:    input.HardwareInfo.CPU,
+		Disk:   input.HardwareInfo.Disk,
 	}
-	// 코어 탐색 완료 후 즉시 해제 — 이후 CMS/Guacamole 네트워크 콜은 락 없이 진행
-	contextStruct.Resources.RUnlock()
 
-	if selectedCore == nil {
-		log.Error("No suitable core found! Total cores: %d, Alive cores: %d, Required: Memory=%d CPU=%d Disk=%d",
-			len(contextStruct.Resources.Cores), aliveCount, req.HardwareInfo.Memory, req.HardwareInfo.CPU, req.HardwareInfo.Disk, true)
+	log.Info("func CreateVM() memory=%d GiB, cpu=%d, disk=%d GiB", hwReq.Memory, hwReq.CPU, hwReq.Disk, true)
 
-		if aliveCount > 0 {
-			log.DebugError("alive cores:")
-			for i := range contextStruct.Resources.Cores {
-				core := &contextStruct.Resources.Cores[i]
-				if core.IsAlive {
-					log.DebugError("  %s: Memory=%d/%d, CPU=%d/%d, Disk=%d/%d",
-						core.IP, core.FreeMemory, core.CoreInfoIdx.Memory, core.FreeCPU, core.CoreInfoIdx.Cpu, core.FreeDisk, core.CoreInfoIdx.Disk)
-				}
-			}
-		} else {
-			log.DebugError("no alive cores available")
-		}
-
-		return fmt.Errorf("CreateVM: no suitable core found")
+	// 1) 코어 선택
+	selectedCore, selectedCoreIndex, err := selectCoreOrFail(contextStruct, hwReq)
+	if err != nil {
+		return err
 	}
-	var privateKeyPEM, publicKeyOpenSSH, err = internalssh.GenerateSSHKey()
+
+	// 2) SSH 키 생성
+	privateKeyPEM, publicKeyOpenSSH, err := internalssh.GenerateSSHKey()
 	if err != nil {
 		log.Error("GenerateSshKey() failed: %v", err, true)
 		return fmt.Errorf("CreateVM: failed to generate SSH key: %w", err)
 	}
 
-	// add : back -> vm uuid    ->  cms   다른 api
-	// new : subnet 찾기 -> cms
+	// 단계별 롤백 등록을 위한 chain
+	cleanup := &cleanupChain{}
 
-	// 문제가 생겼을 때 지우는 무언가
-	var guacamoleConfigured = false
-	var coreResourcesAllocated = false
-	var newSubnetAllocated = false
-	var uuid = vms.UUID(req.UUID.String().(string))
-
-	cleanup := func() {
-		if guacamoleConfigured {
-			log.Info("clean up clean up")
-			if cleanupErr := guacamole.Cleanup(string(uuid), contextStruct.GuacDB); cleanupErr != nil {
-				log.Error("Failed to cleanup Guacamole config during rollback: %v", cleanupErr)
-			}
-		}
-		if coreResourcesAllocated {
-			// VMInfoIdx와 Free* 필드는 여러 핸들러가 동시에 접근하므로 Lock 필요
-			contextStruct.Resources.Lock()
-			delete(selectedCore.VMInfoIdx, uuid)
-			selectedCore.FreeMemory += req.HardwareInfo.Memory
-			selectedCore.FreeCPU += req.HardwareInfo.CPU
-			selectedCore.FreeDisk += req.HardwareInfo.Disk
-			contextStruct.Resources.Unlock()
-		}
-		if newSubnetAllocated {
-			//subnet--
-		}
-	}
-
-	var cmsResp *CmsResponse
-	cmsClient := NewCmsClient()
-
-	if req.Subnettype == "Add" {
-		cmsResp, err = cmsClient.AddCmsSubnet(contextStruct, uuid)
-	} else {
-		cmsResp, err = cmsClient.NewCmsSubnet(contextStruct)
-		newSubnetAllocated = true
-	}
+	// 3) CMS 서브넷 할당 (Add: 기존 서브넷 / New: 신규 서브넷)
+	cmsResp, isNewSubnet, err := allocateCmsSubnet(contextStruct, input.SubnetType, uuid, cleanup)
 	if err != nil {
-		log.Error("CreateVM: failed to configure cms: %v", err, true)
-		return fmt.Errorf("CreateVM: failed to configure cms: %w", err)
+		return err
 	}
 
-	fmt.Printf("%s\n", cmsResp.IP)
-	fmt.Printf("%s\n", cmsResp.MacAddr)
-	fmt.Printf("%s\n", cmsResp.SdnUUID)
+	log.DebugInfo("CMS allocated: ip=%s, mac=%s, sdn=%s", cmsResp.IP, cmsResp.MacAddr, cmsResp.SdnUUID)
 
-	userPass := guacamole.Configure(req.Users[0].Name, string(req.UUID), cmsResp.IP, privateKeyPEM, contextStruct.GuacDB)
-
+	// 4) Guacamole 사용자/커넥션 설정
+	if len(input.Users) == 0 {
+		cleanup.run()
+		return fmt.Errorf("CreateVM: at least one user is required")
+	}
+	userPass := guacamole.Configure(input.Users[0].Name, string(uuid), cmsResp.IP, privateKeyPEM, contextStruct.GuacDB)
 	if userPass == "" {
 		log.Error("CreateVM: failed to configure Guacamole", true)
+		cleanup.run()
 		return fmt.Errorf("CreateVM: failed to configure Guacamole")
 	}
-	guacamoleConfigured = true
+	cleanup.push(func() {
+		log.Info("clean up: guacamole")
+		if err := guacamole.Cleanup(string(uuid), contextStruct.GuacDB); err != nil {
+			log.Error("Failed to cleanup Guacamole config during rollback: %v", err)
+		}
+	})
 
 	newVM := &vms.VMInfo{
 		UUID:         uuid,
 		GuacPassword: userPass,
 		MacAddr:      cmsResp.MacAddr,
-		Memory:       req.HardwareInfo.Memory,
-		Cpu:          req.HardwareInfo.CPU,
-		Disk:         req.HardwareInfo.Disk,
+		Memory:       hwReq.Memory,
+		Cpu:          hwReq.CPU,
+		Disk:         hwReq.Disk,
 		IP_VM:        cmsResp.IP,
 	}
 
-	// VMInfoIdx map 쓰기 + Free* 필드 감소는 원자적으로 처리해야 함
-	// (다른 CreateVM goroutine이 Free* 읽고 같은 코어 선택하는 race 방지)
-	contextStruct.Resources.Lock()
-	if selectedCore.VMInfoIdx == nil {
-		selectedCore.VMInfoIdx = make(map[vms.UUID]*vms.VMInfo)
-	}
-	selectedCore.VMInfoIdx[uuid] = newVM
-	selectedCore.FreeMemory -= req.HardwareInfo.Memory
-	selectedCore.FreeCPU -= req.HardwareInfo.CPU
-	selectedCore.FreeDisk -= req.HardwareInfo.Disk
-	coreResourcesAllocated = true
-	contextStruct.Resources.Unlock()
-	// 이후 HTTP 전송은 락 밖에서 — 네트워크 콜 중 락을 잡으면 다른 요청 전체가 블로킹됨
+	// 5) 코어 자원 할당 (VMInfoIdx + Free* 원자적 갱신)
+	contextStruct.Resources.AllocateResources(selectedCore, uuid, newVM, hwReq)
+	cleanup.push(func() {
+		contextStruct.Resources.DeallocateResources(selectedCore, uuid, hwReq)
+	})
+	log.DebugInfo("core %s updated: FreeMemory=%d, FreeCPU=%d, FreeDisk=%d",
+		selectedCore.IP, selectedCore.FreeMemory, selectedCore.FreeCPU, selectedCore.FreeDisk)
 
-	log.DebugInfo("core %s updated: FreeMemory=%d, FreeCPU=%d, FreeDisk=%d", selectedCore.IP, selectedCore.FreeMemory, selectedCore.FreeCPU, selectedCore.FreeDisk)
-
-	req.NetConf.Ips = []string{cmsResp.IP}
-	req.SdnUUID = cmsResp.SdnUUID
-	req.MacAddr = cmsResp.MacAddr
-	req.NetConf.NetType = 0
-	req.Users[0].SSHAuthorizedKeys = []string{publicKeyOpenSSH}
-
-	vmRedisInfo := model.VMRedisInfo{
+	// 6) Redis에 초기 상태 저장 (Core 호출 전에 — Core가 상태 갱신할 수 있도록)
+	if err := StoreVMInfoToRedis(context.Background(), rdb, VMInfo{
 		UUID:   uuid,
-		CPU:    req.HardwareInfo.CPU,
-		Memory: req.HardwareInfo.Memory,
-		Disk:   req.HardwareInfo.Disk,
+		CPU:    hwReq.CPU,
+		Memory: hwReq.Memory,
+		Disk:   hwReq.Disk,
 		IP:     cmsResp.IP,
-		Status: model.VMStatusUnknown, // prepare begin 으로 초기화 함
-		Time:   time.Now().Unix(),
-	}
-
-	// HTTP 전송 전에 저장을 완료하여 Core에서 업데이트할 수 있도록 순서 보장
-	if err := StoreVMInfoToRedis(context.Background(), rdb, vmRedisInfo); err != nil {
+		Status: VMStatusUnknown,
+	}, time.Now().Unix()); err != nil {
 		log.Warn("failed to store VM info to redis: %v", err, true)
-		// redis 저장 실패를 vm생성 실패로 처리하지는 않음
+		// redis 저장 실패는 vm 생성 실패로 처리하지 않음
 	}
 
-	// Redis 저장 완료 후 HTTP 전송 (Core에서 Redis 업데이트 가능)
+	// 7) Core에 VM 생성 요청 — service DTO를 client contract로 변환
+	coreReq := buildCoreCreateVMRequest(input, cmsResp, publicKeyOpenSSH)
 	coreClient := client.NewCoreClient(selectedCore)
-	_, err = coreClient.CreateVM(context.Background(), req)
-	if err != nil {
+	if _, err := coreClient.CreateVM(context.Background(), coreReq); err != nil {
 		log.Error("Error creating VM on core %s: %v", selectedCore.IP, err, true)
-		cleanup() // 직접 지우지 말고 요 함수 하나로--
+		cleanup.run()
 		return fmt.Errorf("CreateVM: failed to create VM on core %s: %w", selectedCore.IP, err)
 	}
 
-	err = contextStruct.VMRepo.AddInstance(newVM, selectedCoreIndex)
-	if err != nil {
+	// 8) DB에 인스턴스 정보 영속화
+	if err := contextStruct.VMRepo.AddInstance(newVM, selectedCoreIndex); err != nil {
 		log.Error("Error database instance insertion failed: %v", err, true)
-		cleanup() // 직접 지우지 말고 요 함수 하나로--
+		cleanup.run()
+		return fmt.Errorf("CreateVM: failed to persist instance: %w", err)
 	}
 
-	if newSubnetAllocated {
-		_, err := contextStruct.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = '1'", cmsResp.IP)
-		if err != nil {
-			log.Error("Error database Subnet insertion failed: %v", err, true)
+	// 8-1) 신규 서브넷 할당이었다면 last_subnet을 실제 할당된 IP로 갱신
+	// (NewCmsSubnet에서 계산값으로 선점한 것을 CMS 응답값으로 정정)
+	if isNewSubnet {
+		if _, err := contextStruct.DB.Exec("UPDATE subnet SET last_subnet = ? WHERE id = '1'", cmsResp.IP); err != nil {
+			log.Error("Error database Subnet update failed: %v", err, true)
 		}
 	}
 
-	// VMLocation map과 AliveVM slice를 하나의 Lock으로 묶어 일관성 보장
-	// (VMLocation에는 있는데 AliveVM에는 없는 중간 상태가 노출되지 않도록)
-	contextStruct.Resources.Lock()
-	contextStruct.Resources.VMLocation[uuid] = &contextStruct.Resources.Cores[selectedCoreIndex]
-	contextStruct.Resources.AliveVM = append(contextStruct.Resources.AliveVM, newVM)
-	contextStruct.Resources.Unlock()
+	contextStruct.Resources.RegisterVM(uuid, &contextStruct.Resources.Cores[selectedCoreIndex], newVM)
 	log.Info("VM %s added to ControlContext", uuid, true)
 
 	log.Info("UUID %s CreateVM request success on core %s", uuid, selectedCore.IP, true)
 	return nil
 }
 
+// 추후 Mapper 계층이 필요할 것으로 예상됨
+func buildCoreCreateVMRequest(input CreateVMInput, cmsResp *client.CmsResponse, publicKeyOpenSSH string) model.CreateVMRequest {
+	users := make([]model.UserInfoVM, len(input.Users))
+	for i, u := range input.Users {
+		users[i] = model.UserInfoVM{
+			Name:              u.Name,
+			Groups:            u.Groups,
+			Password:          u.Password,
+			SSHAuthorizedKeys: u.SSHAuthorizedKeys,
+		}
+	}
+	// 첫 번째 사용자는 생성 시 발급한 SSH 공개키를 사용
+	if len(users) > 0 {
+		users[0].SSHAuthorizedKeys = []string{publicKeyOpenSSH}
+	}
+	return model.CreateVMRequest{
+		DomType:      input.DomType,
+		DomName:      input.DomName,
+		UUID:         input.UUID,
+		OS:           input.OS,
+		HardwareInfo: model.HardwareInfo{CPU: input.HardwareInfo.CPU, Memory: input.HardwareInfo.Memory, Disk: input.HardwareInfo.Disk},
+		NetConf:      model.NetDefine{Ips: []string{cmsResp.IP}, NetType: 0},
+		Users:        users,
+		SdnUUID:      cmsResp.SdnUUID,
+		MacAddr:      cmsResp.MacAddr,
+		Subnettype:   input.SubnetType,
+	}
+}
+
+// selectCoreOrFail은 코어 선택 + 실패 시 진단 로그 출력 캡슐화를 진행
+func selectCoreOrFail(contextStruct *vms.ControlContext, req vms.HardwareRequirement) (*vms.Core, int, error) {
+	log := util.GetLogger()
+
+	log.DebugInfo("core selection process. req: memory=%d GiB, cpu=%d, disk=%d", req.Memory, req.CPU, req.Disk)
+	result := contextStruct.Resources.SelectCore(req)
+
+	if result.Core != nil {
+		log.DebugInfo("core found: %s (idx=%d)", result.Core.IP, result.Index)
+		return result.Core, result.Index, nil
+	}
+
+	log.Error("No suitable core found! Total cores: %d, Alive cores: %d, Required: Memory=%d CPU=%d Disk=%d",
+		result.TotalCores, result.AliveCount, req.Memory, req.CPU, req.Disk, true)
+
+	if result.AliveCount > 0 {
+		log.DebugError("alive cores:")
+		contextStruct.Resources.RLock()
+		for i := range contextStruct.Resources.Cores {
+			core := &contextStruct.Resources.Cores[i]
+			if core.IsAlive {
+				log.DebugError("  %s: Memory=%d/%d, CPU=%d/%d, Disk=%d/%d",
+					core.IP, core.FreeMemory, core.CoreInfoIdx.Memory,
+					core.FreeCPU, core.CoreInfoIdx.Cpu,
+					core.FreeDisk, core.CoreInfoIdx.Disk)
+			}
+		}
+		contextStruct.Resources.RUnlock()
+	} else {
+		log.DebugError("no alive cores available")
+	}
+
+	return nil, -1, fmt.Errorf("CreateVM: no suitable core found")
+}
+
+func allocateCmsSubnet(contextStruct *vms.ControlContext, subnetType string, uuid vms.UUID, cleanup *cleanupChain) (*client.CmsResponse, bool, error) {
+	log := util.GetLogger()
+	cmsClient := client.NewCmsClient()
+
+	if subnetType == "Add" {
+		resp, err := AddCmsSubnet(cmsClient, contextStruct, uuid)
+		if err != nil {
+			log.Error("CreateVM: failed to configure cms (Add): %v", err, true)
+			return nil, false, fmt.Errorf("CreateVM: failed to configure cms: %w", err)
+		}
+		return resp, false, nil
+	}
+
+	resp, err := NewCmsSubnet(cmsClient, contextStruct)
+	if err != nil {
+		log.Error("CreateVM: failed to configure cms (New): %v", err, true)
+		return nil, false, fmt.Errorf("CreateVM: failed to configure cms: %w", err)
+	}
+	// 신규 서브넷 할당 시: 후속 단계 실패에 대한 별도 DB 롤백 로직은 미구현 상태 (TODO)
+	cleanup.push(func() {
+		log.Warn("clean up: new subnet allocation rollback is not implemented")
+	})
+	return resp, true, nil
+}
+
 func DeleteVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Client) error {
 	log := util.GetLogger()
+
 	core := contextStruct.FindCoreByVmUUID(uuid)
 	if core == nil {
 		log.Error("VM with UUID %s not found", string(uuid))
 		return fmt.Errorf("VM with UUID %s not found", string(uuid))
 	}
 
+	// 1) Core에 VM 삭제 요청
 	coreClient := client.NewCoreClient(core)
-	_, err := coreClient.DeleteVM(context.Background(), model.DeleteVMRequest{
+	if _, err := coreClient.DeleteVM(context.Background(), model.DeleteVMRequest{
 		UUID: uuid,
 		Type: model.HardDelete,
-	})
-	if err != nil {
+	}); err != nil {
 		log.Error("error deleting VM %s on core %s: %v", uuid, core.IP, err)
 		return fmt.Errorf("DeleteVM: failed to delete VM %s on core %s: %w", uuid, core.IP, err)
 	}
 
-	err = contextStruct.VMRepo.DeleteInstance(uuid)
-	if err != nil {
-		log.Error("error deleting instance %s from ControlContext: %v", uuid, err)
+	// 2) DB에서 인스턴스 정보 삭제
+	if err := contextStruct.VMRepo.DeleteInstance(uuid); err != nil {
+		log.Error("error deleting instance %s from DB: %v", uuid, err)
 		return fmt.Errorf("DeleteVM: failed to delete instance %s: %w", uuid, err)
 	}
-	if cleanupErr := guacamole.Cleanup(string(uuid), contextStruct.GuacDB); cleanupErr != nil {
-		log.Error("Failed to cleanup Guacamole config during rollback: %v", cleanupErr)
+
+	// 3) Guacamole 사용자/커넥션 정리
+	if err := guacamole.Cleanup(string(uuid), contextStruct.GuacDB); err != nil {
+		log.Error("Failed to cleanup Guacamole config: %v", err)
 	}
 
+	// 4) Redis 정리 (실패해도 삭제 자체는 성공으로 처리 추가 처리 로직 필요)
 	if err := RemoveVMInfoFromRedis(context.Background(), rdb, uuid); err != nil {
 		log.Warn("failed to remove vm info from redis (vm deletion succeeded but..): %v", err, true)
-		// 얘도 create할 때처럼 redis 값 삭제 실패를 했을 때 del vm 자체를 실패했다고 처리하지는 않음
-		// 물론 어케 처리할지 고민을..
 	}
 
 	return nil
 }
+
 func StartVM(uuid vms.UUID, contextStruct *vms.ControlContext) error {
 	log := util.GetLogger()
 
@@ -285,10 +266,7 @@ func StartVM(uuid vms.UUID, contextStruct *vms.ControlContext) error {
 	}
 
 	coreClient := client.NewCoreClient(core)
-	_, err := coreClient.StartVM(context.Background(), model.StartVMRequest{
-		UUID: uuid,
-	})
-	if err != nil {
+	if _, err := coreClient.StartVM(context.Background(), model.StartVMRequest{UUID: uuid}); err != nil {
 		return fmt.Errorf("StartVM: failed to start VM %s: %w", uuid, err)
 	}
 
@@ -303,96 +281,85 @@ func ShutdownVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Cli
 	}
 
 	coreClient := client.NewCoreClient(core)
-	_, err := coreClient.ForceShutdownVM(context.Background(), model.ForceShutdownVMRequest{
-		UUID: uuid,
-	})
-
-	if err != nil {
+	if _, err := coreClient.ForceShutdownVM(context.Background(), model.ForceShutdownVMRequest{UUID: uuid}); err != nil {
 		return fmt.Errorf("ShutdownVM: failed to shutdown VM %s: %w", uuid, err)
 	}
 
-	foundIndex := -1
-	// 탐색과 삭제를 하나의 Lock 안에서 — 탐색 후 삭제 전에 다른 goroutine이 AliveVM을 바꾸면 index가 틀어짐
-	contextStruct.Resources.Lock()
-	for i, vm := range contextStruct.Resources.AliveVM {
-		if vm.UUID == uuid {
-			foundIndex = i
-			break
-		}
-	}
+	contextStruct.Resources.UnregisterAlive(uuid)
 
-	if foundIndex != -1 {
-		contextStruct.Resources.AliveVM = slices.Delete(contextStruct.Resources.AliveVM, foundIndex, foundIndex+1)
-	}
-	contextStruct.Resources.Unlock()
-
-	if err := UpdateVMStatusInRedis(context.Background(), rdb, uuid, model.VMStatusStopped, time.Now().Unix()); err != nil {
-		log := util.GetLogger()
-		log.Warn("failed to update vm status in redis %v", err, true)
+	if err := UpdateVMStatusInRedis(context.Background(), rdb, uuid, VMStatusStopped, time.Now().Unix()); err != nil {
+		util.GetLogger().Warn("failed to update vm status in redis %v", err, true)
 	}
 
 	return nil
 }
 
-func GetVMCpuInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (model.CoreMachineCpuInfoResponse, error) {
+func GetVMCpuInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (VMCpuStatus, error) {
 	log := util.GetLogger()
 
 	core := contextStruct.FindCoreByVmUUID(uuid)
 	if core == nil {
 		log.Error("GetVMCpuInfo: VM with UUID %s not found", string(uuid), true)
-		return model.CoreMachineCpuInfoResponse{}, fmt.Errorf("GetVMCpuInfo: VM with UUID %s not found", string(uuid))
+		return VMCpuStatus{}, fmt.Errorf("GetVMCpuInfo: VM with UUID %s not found", string(uuid))
 	}
 
 	coreClient := client.NewCoreClient(core)
-
 	cpuInfo, err := coreClient.GetVMCpuInfo(context.Background(), uuid)
 	if err != nil {
 		log.Error("GetVMCpuInfo: error getting CPU info for VM %s on core %s: %v", uuid, core.IP, err, true)
-		return model.CoreMachineCpuInfoResponse{}, fmt.Errorf("GetVMCpuInfo: error getting CPU info for VM %s on core %s: %w", uuid, core.IP, err)
+		return VMCpuStatus{}, fmt.Errorf("GetVMCpuInfo: error getting CPU info for VM %s on core %s: %w", uuid, core.IP, err)
 	}
 
 	log.DebugInfo("Retrieved CPU status for VM %s on core %s", uuid, core.IP)
-	return cpuInfo, nil
+	return VMCpuStatus{System: cpuInfo.System, Idle: cpuInfo.Idle, Usage: cpuInfo.Usage}, nil
 }
 
-func GetVMMemoryInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (model.CoreMachineMemoryInfoResponse, error) {
+func GetVMMemoryInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (VMMemoryStatus, error) {
 	log := util.GetLogger()
 
 	core := contextStruct.FindCoreByVmUUID(uuid)
 	if core == nil {
 		log.Error("GetVMMemoryInfo: VM with UUID %s not found", string(uuid), true)
-		return model.CoreMachineMemoryInfoResponse{}, fmt.Errorf("GetVMMemoryInfo: VM with UUID %s not found", string(uuid))
+		return VMMemoryStatus{}, fmt.Errorf("GetVMMemoryInfo: VM with UUID %s not found", string(uuid))
 	}
 
 	coreClient := client.NewCoreClient(core)
-
 	memoryInfo, err := coreClient.GetVMMemoryInfo(context.Background(), uuid)
 	if err != nil {
 		log.Error("GetVMMemoryInfo: error getting memory info for VM %s on core %s: %v", uuid, core.IP, err, true)
-		return model.CoreMachineMemoryInfoResponse{}, fmt.Errorf("GetVMMemoryInfo: error getting memory info for VM %s on core %s: %w", uuid, core.IP, err)
+		return VMMemoryStatus{}, fmt.Errorf("GetVMMemoryInfo: error getting memory info for VM %s on core %s: %w", uuid, core.IP, err)
 	}
 
 	log.DebugInfo("Retrieved Memory status for VM %s on core %s", uuid, core.IP)
-	return memoryInfo, nil
+	return VMMemoryStatus{
+		Total:       memoryInfo.Total,
+		Used:        memoryInfo.Used,
+		Available:   memoryInfo.Available,
+		UsedPercent: memoryInfo.UsedPercent,
+	}, nil
 }
 
-func GetVMDiskInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (model.CoreMachineDiskInfoResponse, error) {
+func GetVMDiskInfo(uuid vms.UUID, contextStruct *vms.ControlContext) (VMDiskStatus, error) {
 	log := util.GetLogger()
 
 	core := contextStruct.FindCoreByVmUUID(uuid)
 	if core == nil {
 		log.Error("GetVMDiskInfo: VM with UUID %s not found", string(uuid), true)
-		return model.CoreMachineDiskInfoResponse{}, fmt.Errorf("GetVMDiskInfo: VM with UUID %s not found", string(uuid))
+		return VMDiskStatus{}, fmt.Errorf("GetVMDiskInfo: VM with UUID %s not found", string(uuid))
 	}
 
 	coreClient := client.NewCoreClient(core)
-
 	diskInfo, err := coreClient.GetVMDiskInfo(context.Background(), uuid)
 	if err != nil {
 		log.Error("GetVMDiskInfo: error getting disk info for VM %s on core %s: %v", uuid, core.IP, err, true)
-		return model.CoreMachineDiskInfoResponse{}, fmt.Errorf("GetVMDiskInfo: error getting disk info for VM %s on core %s: %w", uuid, core.IP, err)
+		return VMDiskStatus{}, fmt.Errorf("GetVMDiskInfo: error getting disk info for VM %s on core %s: %w", uuid, core.IP, err)
 	}
 
 	log.DebugInfo("Retrieved Disk status for VM %s on core %s", uuid, core.IP)
-	return diskInfo, nil
+	return VMDiskStatus{
+		Total:       diskInfo.Total,
+		Used:        diskInfo.Used,
+		Free:        diskInfo.Free,
+		UsedPercent: diskInfo.UsedPercent,
+	}, nil
 }

--- a/service/vm.go
+++ b/service/vm.go
@@ -36,10 +36,10 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	aliveCount := 0
 
 	// Cores/FreeMemory 등 공유 상태를 읽으므로 RLock (동시 읽기는 허용, 쓰기만 차단)
-	contextStruct.RLock()
-	for i := range contextStruct.Cores {
+	contextStruct.Resources.RLock()
+	for i := range contextStruct.Resources.Cores {
 
-		core := &contextStruct.Cores[i]
+		core := &contextStruct.Resources.Cores[i]
 		log.DebugInfo("core %s checking: FreeMemory=%d, FreeCPU=%d, FreeDisk=%d, IsAlive=%t", core.IP, core.FreeMemory, core.FreeCPU, core.FreeDisk, core.IsAlive)
 
 		if !core.IsAlive {
@@ -76,16 +76,16 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		}
 	}
 	// 코어 탐색 완료 후 즉시 해제 — 이후 CMS/Guacamole 네트워크 콜은 락 없이 진행
-	contextStruct.RUnlock()
+	contextStruct.Resources.RUnlock()
 
 	if selectedCore == nil {
 		log.Error("No suitable core found! Total cores: %d, Alive cores: %d, Required: Memory=%d CPU=%d Disk=%d",
-			len(contextStruct.Cores), aliveCount, req.HardwareInfo.Memory, req.HardwareInfo.CPU, req.HardwareInfo.Disk, true)
+			len(contextStruct.Resources.Cores), aliveCount, req.HardwareInfo.Memory, req.HardwareInfo.CPU, req.HardwareInfo.Disk, true)
 
 		if aliveCount > 0 {
 			log.DebugError("alive cores:")
-			for i := range contextStruct.Cores {
-				core := &contextStruct.Cores[i]
+			for i := range contextStruct.Resources.Cores {
+				core := &contextStruct.Resources.Cores[i]
 				if core.IsAlive {
 					log.DebugError("  %s: Memory=%d/%d, CPU=%d/%d, Disk=%d/%d",
 						core.IP, core.FreeMemory, core.CoreInfoIdx.Memory, core.FreeCPU, core.CoreInfoIdx.Cpu, core.FreeDisk, core.CoreInfoIdx.Disk)
@@ -121,12 +121,12 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		}
 		if coreResourcesAllocated {
 			// VMInfoIdx와 Free* 필드는 여러 핸들러가 동시에 접근하므로 Lock 필요
-			contextStruct.Lock()
+			contextStruct.Resources.Lock()
 			delete(selectedCore.VMInfoIdx, uuid)
 			selectedCore.FreeMemory += req.HardwareInfo.Memory
 			selectedCore.FreeCPU += req.HardwareInfo.CPU
 			selectedCore.FreeDisk += req.HardwareInfo.Disk
-			contextStruct.Unlock()
+			contextStruct.Resources.Unlock()
 		}
 		if newSubnetAllocated {
 			//subnet--
@@ -171,7 +171,7 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 
 	// VMInfoIdx map 쓰기 + Free* 필드 감소는 원자적으로 처리해야 함
 	// (다른 CreateVM goroutine이 Free* 읽고 같은 코어 선택하는 race 방지)
-	contextStruct.Lock()
+	contextStruct.Resources.Lock()
 	if selectedCore.VMInfoIdx == nil {
 		selectedCore.VMInfoIdx = make(map[vms.UUID]*vms.VMInfo)
 	}
@@ -180,7 +180,7 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 	selectedCore.FreeCPU -= req.HardwareInfo.CPU
 	selectedCore.FreeDisk -= req.HardwareInfo.Disk
 	coreResourcesAllocated = true
-	contextStruct.Unlock()
+	contextStruct.Resources.Unlock()
 	// 이후 HTTP 전송은 락 밖에서 — 네트워크 콜 중 락을 잡으면 다른 요청 전체가 블로킹됨
 
 	log.DebugInfo("core %s updated: FreeMemory=%d, FreeCPU=%d, FreeDisk=%d", selectedCore.IP, selectedCore.FreeMemory, selectedCore.FreeCPU, selectedCore.FreeDisk)
@@ -216,7 +216,7 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 		return fmt.Errorf("CreateVM: failed to create VM on core %s: %w", selectedCore.IP, err)
 	}
 
-	err = contextStruct.AddInstance(newVM, selectedCoreIndex)
+	err = contextStruct.VMRepo.AddInstance(newVM, selectedCoreIndex)
 	if err != nil {
 		log.Error("Error database instance insertion failed: %v", err, true)
 		cleanup() // 직접 지우지 말고 요 함수 하나로--
@@ -231,13 +231,10 @@ func CreateVM(req model.CreateVMRequest, contextStruct *vms.ControlContext, rdb 
 
 	// VMLocation map과 AliveVM slice를 하나의 Lock으로 묶어 일관성 보장
 	// (VMLocation에는 있는데 AliveVM에는 없는 중간 상태가 노출되지 않도록)
-	contextStruct.Lock()
-	if contextStruct.VMLocation == nil {
-		contextStruct.VMLocation = make(map[vms.UUID]*vms.Core)
-	}
-	contextStruct.VMLocation[uuid] = &contextStruct.Cores[selectedCoreIndex]
-	contextStruct.AliveVM = append(contextStruct.AliveVM, newVM)
-	contextStruct.Unlock()
+	contextStruct.Resources.Lock()
+	contextStruct.Resources.VMLocation[uuid] = &contextStruct.Resources.Cores[selectedCoreIndex]
+	contextStruct.Resources.AliveVM = append(contextStruct.Resources.AliveVM, newVM)
+	contextStruct.Resources.Unlock()
 	log.Info("VM %s added to ControlContext", uuid, true)
 
 	log.Info("UUID %s CreateVM request success on core %s", uuid, selectedCore.IP, true)
@@ -262,7 +259,7 @@ func DeleteVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Clien
 		return fmt.Errorf("DeleteVM: failed to delete VM %s on core %s: %w", uuid, core.IP, err)
 	}
 
-	err = contextStruct.DeleteInstance(uuid)
+	err = contextStruct.VMRepo.DeleteInstance(uuid)
 	if err != nil {
 		log.Error("error deleting instance %s from ControlContext: %v", uuid, err)
 		return fmt.Errorf("DeleteVM: failed to delete instance %s: %w", uuid, err)
@@ -316,8 +313,8 @@ func ShutdownVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Cli
 
 	foundIndex := -1
 	// 탐색과 삭제를 하나의 Lock 안에서 — 탐색 후 삭제 전에 다른 goroutine이 AliveVM을 바꾸면 index가 틀어짐
-	contextStruct.Lock()
-	for i, vm := range contextStruct.AliveVM {
+	contextStruct.Resources.Lock()
+	for i, vm := range contextStruct.Resources.AliveVM {
 		if vm.UUID == uuid {
 			foundIndex = i
 			break
@@ -325,9 +322,9 @@ func ShutdownVM(uuid vms.UUID, contextStruct *vms.ControlContext, rdb *redis.Cli
 	}
 
 	if foundIndex != -1 {
-		contextStruct.AliveVM = slices.Delete(contextStruct.AliveVM, foundIndex, foundIndex+1)
+		contextStruct.Resources.AliveVM = slices.Delete(contextStruct.Resources.AliveVM, foundIndex, foundIndex+1)
 	}
-	contextStruct.Unlock()
+	contextStruct.Resources.Unlock()
 
 	if err := UpdateVMStatusInRedis(context.Background(), rdb, uuid, model.VMStatusStopped, time.Now().Unix()); err != nil {
 		log := util.GetLogger()

--- a/startup/init.go
+++ b/startup/init.go
@@ -146,6 +146,8 @@ func InitializeCoreData(configPath string) (structure.ControlContext, error) {
 	infra.Config = config
 	infra.GuacDB = db
 	infra.DB = mainDB
+	infra.VMRepo = structure.NewMySQLVMRepository(mainDB)
+	infra.Resources = structure.NewResourceManager()
 
 	var last_subnet_db string
 	err = infra.DB.QueryRow("SELECT last_subnet from core_base.subnet where id = '1'").Scan(&last_subnet_db)
@@ -154,12 +156,11 @@ func InitializeCoreData(configPath string) (structure.ControlContext, error) {
 	}
 	infra.Last_subnet = last_subnet_db
 	// 모든 Core 정의
-	infra.VMLocation = make(map[structure.UUID]*structure.Core)
-	for i := range infra.Cores {
-		for vmUUID := range infra.Cores[i].VMInfoIdx {
-			infra.VMLocation[vmUUID] = &infra.Cores[i]
+	for i := range infra.Resources.Cores {
+		for vmUUID := range infra.Resources.Cores[i].VMInfoIdx {
+			infra.Resources.VMLocation[vmUUID] = &infra.Resources.Cores[i]
 		}
-		infra.Cores[i].IsAlive = false
+		infra.Resources.Cores[i].IsAlive = false
 	}
 
 	// config에 설정된 코어에 대해서 정보 업데이트
@@ -185,15 +186,15 @@ func InitializeCoreData(configPath string) (structure.ControlContext, error) {
 			return structure.ControlContext{}, fmt.Errorf("error converting port number from %s: %w", coreAddress, err)
 		}
 
-		core := findCore(infra.Cores, ip, uint16(port))
+		core := findCore(infra.Resources.Cores, ip, uint16(port))
 		if core == nil {
 			newCore := structure.Core{
 				IP:      ip,
 				Port:    uint16(port),
 				IsAlive: true,
 			}
-			infra.Cores = append(infra.Cores, newCore)
-			core = &infra.Cores[len(infra.Cores)-1]
+			infra.Resources.Cores = append(infra.Resources.Cores, newCore)
+			core = &infra.Resources.Cores[len(infra.Resources.Cores)-1]
 			log.DebugInfo("Added new core: %s:%d", ip, port)
 		} else {
 			core.IsAlive = true
@@ -243,23 +244,23 @@ func InitializeCoreData(configPath string) (structure.ControlContext, error) {
 		return structure.ControlContext{}, fmt.Errorf("failed to get core info: %w", err)
 	}
 
-	vmInfoList, coreIdxList, err := infra.GetAllInstanceInfo()
+	vmInfoList, coreIdxList, err := infra.VMRepo.GetAllInstanceInfo()
 	if err != nil {
 		return structure.ControlContext{}, fmt.Errorf("failed to get all instance info: %w", err)
 	}
 
 	for i, vmInfo := range vmInfoList {
 		coreIdx := coreIdxList[i]
-		if coreIdx < 0 || coreIdx >= len(infra.Cores) {
+		if coreIdx < 0 || coreIdx >= len(infra.Resources.Cores) {
 			return structure.ControlContext{}, fmt.Errorf("core index %d out of range for core list", coreIdx)
 		}
-		core := &infra.Cores[coreIdx]
+		core := &infra.Resources.Cores[coreIdx]
 		if core.VMInfoIdx == nil {
 			core.VMInfoIdx = make(map[structure.UUID]*structure.VMInfo)
 		}
 		if _, exists := core.VMInfoIdx[vmInfo.UUID]; !exists {
 			core.VMInfoIdx[vmInfo.UUID] = &vmInfo
-			infra.VMLocation[vmInfo.UUID] = core
+			infra.Resources.VMLocation[vmInfo.UUID] = core
 		} else {
 			log.DebugInfo("VM %s already exists in core %d, skipping", vmInfo.UUID, coreIdx)
 		}

--- a/structure/control_infra.go
+++ b/structure/control_infra.go
@@ -15,17 +15,31 @@ type ControlContext struct {
 	Last_subnet string
 }
 
+// FindCoreByVmUUID search cores for the given VM UUID and returns the corresponding Core.
 func (c *ControlContext) FindCoreByVmUUID(uuid UUID) *Core {
 	log := util.GetLogger()
 
+	// Searching in-memory cache
+	c.Resources.RLock()
+	if core, ok := c.Resources.VMLocation[uuid]; ok {
+		c.Resources.RUnlock()
+		return core
+	}
+	c.Resources.RUnlock()
+
+	// If not found in cache, query the repository
 	coreIdx, err := c.VMRepo.GetInstanceLocation(uuid)
 	if err != nil {
 		log.Error("Core not found for VM UUID %s", uuid, true)
 		return nil
 	}
+	c.Resources.Lock()
+	defer c.Resources.Unlock()
 	if coreIdx < 0 || coreIdx >= len(c.Resources.Cores) {
 		log.Error("Core index %d out of range for VM UUID %s", coreIdx, uuid, true)
 		return nil
 	}
-	return &c.Resources.Cores[coreIdx]
+	core := &c.Resources.Cores[coreIdx]
+	c.Resources.VMLocation[uuid] = core
+	return core
 }

--- a/structure/control_infra.go
+++ b/structure/control_infra.go
@@ -1,210 +1,31 @@
 package structure
 
 import (
-	"context"
 	"database/sql"
-	"sync"
-	"time"
 
 	"github.com/easy-cloud-Knet/KWS_Control/util"
 )
 
 type ControlContext struct {
-	mu          sync.RWMutex
+	VMRepo      VMRepository
+	Resources   *ResourceManager
 	Config      Config
-	DB          *sql.DB
+	DB          *sql.DB // subnet 등 직접 쿼리용 (추후 별도 Repository로 분리 예정)
 	GuacDB      *sql.DB
 	Last_subnet string
-	Cores       []Core         // 모든 코어를 관리
-	AliveVM     []*VMInfo      //현재 가동중인 VM의 정보
-	VMLocation  map[UUID]*Core //UUID를 기반으로 어떤 VM이 어느 Core에 있는지 확인하는 포인터
-	// => 여기에다가는 사실 core에 ip주소를 기반으로 어느 ip에 어느 UUID를 가진 VM이 있는지만 확인할 수 있으면 될거같아요.
-	// => 근데 이거 자료형을 어떤걸 써야할지 모르겠어서 일단 이렇게 map[UUID]*Core로 해놓은거지 2차원 벡터로 해도 무방할거 같습니다.
-	// => 이렇게 한 이유는 이전 버전에서 VMPool map[UUID]*VM 이렇게 해놓았던데 이렇게 하면 VM이 많아졌을 때 너무 오래 걸릴거 같아서 IP를 기반으로 먼저 찾고 해당 core로 넘어가서 처리하면 더 좋지않을까? 생각했어요.
 }
-
-func (c *ControlContext) Lock()    { c.mu.Lock() }
-func (c *ControlContext) Unlock()  { c.mu.Unlock() }
-func (c *ControlContext) RLock()   { c.mu.RLock() }
-func (c *ControlContext) RUnlock() { c.mu.RUnlock() }
 
 func (c *ControlContext) FindCoreByVmUUID(uuid UUID) *Core {
 	log := util.GetLogger()
 
-	coreIdx, err := c.GetInstanceLocation(uuid)
+	coreIdx, err := c.VMRepo.GetInstanceLocation(uuid)
 	if err != nil {
 		log.Error("Core not found for VM UUID %s", uuid, true)
 		return nil
 	}
-	return &c.Cores[coreIdx]
-}
-
-func (contextStructure *ControlContext) AddInstance(instanceInfo *VMInfo, coreIdx int) error {
-	log := util.GetLogger()
-	tx, err := contextStructure.DB.Begin()
-	if err != nil {
-		log.Error("Failed to start transaction %v", err)
-		return err
+	if coreIdx < 0 || coreIdx >= len(c.Resources.Cores) {
+		log.Error("Core index %d out of range for VM UUID %s", coreIdx, uuid, true)
+		return nil
 	}
-	defer tx.Rollback()
-
-	// Set timeout for the transaction
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err = tx.ExecContext(ctx, "INSERT INTO inst_info (uuid, inst_ip, guac_pass, inst_mem, inst_vcpu, inst_disk) VALUES (?, ?, ?, ?, ?, ?)",
-		string(instanceInfo.UUID),
-		instanceInfo.IP_VM,
-		instanceInfo.GuacPassword,
-		instanceInfo.Memory,
-		instanceInfo.Cpu,
-		instanceInfo.Disk)
-	if err != nil {
-		log.Error("Failed to insert instance info: %v", err)
-		return err
-	}
-	_, err = tx.ExecContext(ctx, "INSERT INTO inst_loc (uuid, core) VALUES (?, ?)",
-		string(instanceInfo.UUID),
-		coreIdx)
-	if err != nil {
-		log.Error("Failed to insert instance core relation: %v", err)
-		return err
-	}
-	return tx.Commit()
-}
-
-// 현재 미사용중
-// 이건 미사용중이면 안되지않나? 인스턴스정보 DB에 업데이트 하는거같은데
-func (contextStructure *ControlContext) UpdateInstance(instanceInfo *VMInfo) error {
-	log := util.GetLogger()
-	tx, err := contextStructure.DB.Begin()
-	if err != nil {
-		log.Error("Failed to start transaction %v", err)
-		return err
-	}
-	defer tx.Rollback()
-
-	//Set timeout for the transaction
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	_, err = tx.ExecContext(ctx, "UPDATE inst_info SET inst_ip = ?, inst_mem = ?, inst_vcpu = ?, inst_disk = ? WHERE uuid = ?",
-		instanceInfo.IP_VM,
-		instanceInfo.Memory,
-		instanceInfo.Cpu,
-		instanceInfo.Disk,
-		string(instanceInfo.UUID))
-	if err != nil {
-		log.Error("Failed to update instance info: %v", err)
-		return err
-	}
-	return tx.Commit()
-}
-
-func (contextStructure *ControlContext) DeleteInstance(uuid UUID) error {
-	log := util.GetLogger()
-	tx, err := contextStructure.DB.Begin()
-	if err != nil {
-		log.Error("Failed to start transaction: %v", err)
-		return err
-	}
-	defer tx.Rollback()
-	// Set timeout for the transaction
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err = tx.ExecContext(ctx, "DELETE FROM inst_info WHERE uuid = ?", uuid)
-	if err != nil {
-		return err
-	}
-	_, err = tx.ExecContext(ctx, "DELETE FROM inst_loc WHERE uuid = ?", uuid)
-	if err != nil {
-		return err
-	}
-	return tx.Commit()
-}
-
-func (contextStructure *ControlContext) GetInstance(uuid UUID) (*VMInfo, error) {
-	log := util.GetLogger()
-	tx, err := contextStructure.DB.Begin()
-	if err != nil {
-		log.Error("Failed to start transaction: %v", err)
-		return nil, err
-	}
-	defer tx.Rollback()
-	//set timeout for the transaction
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	var instance VMInfo
-	err = tx.QueryRowContext(ctx, "SELECT uuid, inst_ip, guac_pass, inst_mem, inst_vcpu, inst_disk FROM inst_info WHERE uuid = ?", uuid).Scan(
-		&instance.UUID,
-		&instance.IP_VM,
-		&instance.GuacPassword,
-		&instance.Memory,
-		&instance.Cpu,
-		&instance.Disk)
-	if err != nil {
-		log.Error("Failed to get instance info: %v", err)
-		return nil, err
-	}
-	return &instance, tx.Commit()
-}
-
-func (contextStructure *ControlContext) GetInstanceLocation(uuid UUID) (int, error) {
-	log := util.GetLogger()
-	tx, err := contextStructure.DB.Begin()
-	if err != nil {
-		log.Error("Failed to start transaction: %v", err)
-		return 0, err
-	}
-	defer tx.Rollback()
-	//set timeout for the transaction
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	var coreIdx int
-	err = tx.QueryRowContext(ctx, "SELECT core FROM inst_loc WHERE uuid = ?", uuid).Scan(&coreIdx)
-	if err != nil {
-		log.Error("Failed to get instance location: %v", err)
-		return 0, err
-	}
-	return coreIdx, tx.Commit()
-}
-
-func (contextStructure *ControlContext) GetAllInstanceInfo() ([]VMInfo, []int, error) {
-	log := util.GetLogger()
-	tx, err := contextStructure.DB.Begin()
-	if err != nil {
-		log.Error("Failed to start transaction: %v", err)
-		return nil, nil, err
-	}
-	defer tx.Rollback()
-	//set timeout for the transaction
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	var rows *sql.Rows
-	rows, err = tx.QueryContext(ctx, "SELECT info.uuid, loc.core, info.inst_ip, info.guac_pass, info.inst_vcpu, info.inst_mem, info.inst_disk FROM inst_loc loc JOIN inst_info info ON loc.uuid = info.uuid")
-	if err != nil {
-		log.Error("Failed to get joined instance info: %v", err)
-		return nil, nil, err
-	}
-
-	var coreIdxList []int
-	var VMInfoList []VMInfo
-
-	for rows.Next() {
-		var coreIdx int
-		var info VMInfo
-
-		if err := rows.Scan(&info.UUID, &coreIdx, &info.IP_VM, &info.GuacPassword, &info.Cpu, &info.Memory, &info.Disk); err != nil {
-			log.Error("Failed to scan instance location: %v", err)
-			return nil, nil, err
-		}
-		log.DebugInfo("Found instance: %s on core %d", info.UUID, coreIdx)
-		VMInfoList = append(VMInfoList, info)
-		coreIdxList = append(coreIdxList, coreIdx)
-	}
-	return VMInfoList, coreIdxList, tx.Commit()
+	return &c.Resources.Cores[coreIdx]
 }

--- a/structure/mysql_vm_repository.go
+++ b/structure/mysql_vm_repository.go
@@ -17,17 +17,22 @@ func NewMySQLVMRepository(db *sql.DB) *MySQLVMRepository {
 	return &MySQLVMRepository{DB: db}
 }
 
+// AddInstance adds a new instance to the DB and associates it with a core index.
 func (r *MySQLVMRepository) AddInstance(instanceInfo *VMInfo, coreIdx int) error {
 	log := util.GetLogger()
-	tx, err := r.DB.Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		log.Error("Failed to start transaction %v", err)
 		return err
 	}
-	defer tx.Rollback()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Error("Failed to rollback transaction: %v", err)
+		}
+	}()
 
 	_, err = tx.ExecContext(ctx, "INSERT INTO inst_info (uuid, inst_ip, guac_pass, inst_mem, inst_vcpu, inst_disk) VALUES (?, ?, ?, ?, ?, ?)",
 		string(instanceInfo.UUID),
@@ -50,17 +55,23 @@ func (r *MySQLVMRepository) AddInstance(instanceInfo *VMInfo, coreIdx int) error
 	return tx.Commit()
 }
 
+// UpdateInstance updates the instance information in DB for the given VM UUID.
+// Note: Guacamole password is not updated here as it is generated only once at instance creation. If needed, it can be added as well.
 func (r *MySQLVMRepository) UpdateInstance(instanceInfo *VMInfo) error {
 	log := util.GetLogger()
-	tx, err := r.DB.Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		log.Error("Failed to start transaction %v", err)
 		return err
 	}
-	defer tx.Rollback()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Error("Failed to rollback transaction: %v", err)
+		}
+	}()
 
 	_, err = tx.ExecContext(ctx, "UPDATE inst_info SET inst_ip = ?, inst_mem = ?, inst_vcpu = ?, inst_disk = ? WHERE uuid = ?",
 		instanceInfo.IP_VM,
@@ -75,17 +86,22 @@ func (r *MySQLVMRepository) UpdateInstance(instanceInfo *VMInfo) error {
 	return tx.Commit()
 }
 
+// DeleteInstance deletes the instance in DB for the given VM UUID.
 func (r *MySQLVMRepository) DeleteInstance(uuid UUID) error {
 	log := util.GetLogger()
-	tx, err := r.DB.Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		log.Error("Failed to start transaction: %v", err)
 		return err
 	}
-	defer tx.Rollback()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Error("Failed to rollback transaction: %v", err)
+		}
+	}()
 
 	_, err = tx.ExecContext(ctx, "DELETE FROM inst_info WHERE uuid = ?", uuid)
 	if err != nil {
@@ -98,17 +114,22 @@ func (r *MySQLVMRepository) DeleteInstance(uuid UUID) error {
 	return tx.Commit()
 }
 
+// GetInstance returns the Instance information for the given VM UUID.
 func (r *MySQLVMRepository) GetInstance(uuid UUID) (*VMInfo, error) {
 	log := util.GetLogger()
-	tx, err := r.DB.Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		log.Error("Failed to start transaction: %v", err)
 		return nil, err
 	}
-	defer tx.Rollback()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Error("Failed to rollback transaction: %v", err)
+		}
+	}()
 
 	var instance VMInfo
 	err = tx.QueryRowContext(ctx, "SELECT uuid, inst_ip, guac_pass, inst_mem, inst_vcpu, inst_disk FROM inst_info WHERE uuid = ?", uuid).Scan(
@@ -125,17 +146,22 @@ func (r *MySQLVMRepository) GetInstance(uuid UUID) (*VMInfo, error) {
 	return &instance, tx.Commit()
 }
 
+// GetInstanceLocation returns the core index for the given VM UUID.
 func (r *MySQLVMRepository) GetInstanceLocation(uuid UUID) (int, error) {
 	log := util.GetLogger()
-	tx, err := r.DB.Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		log.Error("Failed to start transaction: %v", err)
 		return 0, err
 	}
-	defer tx.Rollback()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Error("Failed to rollback transaction: %v", err)
+		}
+	}()
 
 	var coreIdx int
 	err = tx.QueryRowContext(ctx, "SELECT core FROM inst_loc WHERE uuid = ?", uuid).Scan(&coreIdx)
@@ -146,17 +172,22 @@ func (r *MySQLVMRepository) GetInstanceLocation(uuid UUID) (int, error) {
 	return coreIdx, tx.Commit()
 }
 
+// GetAllInstanceInfo returns the list of all instance information and their corresponding core indices.
 func (r *MySQLVMRepository) GetAllInstanceInfo() ([]VMInfo, []int, error) {
 	log := util.GetLogger()
-	tx, err := r.DB.Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		log.Error("Failed to start transaction: %v", err)
 		return nil, nil, err
 	}
-	defer tx.Rollback()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Error("Failed to rollback transaction: %v", err)
+		}
+	}()
 
 	var rows *sql.Rows
 	rows, err = tx.QueryContext(ctx, "SELECT info.uuid, loc.core, info.inst_ip, info.guac_pass, info.inst_vcpu, info.inst_mem, info.inst_disk FROM inst_loc loc JOIN inst_info info ON loc.uuid = info.uuid")
@@ -180,5 +211,11 @@ func (r *MySQLVMRepository) GetAllInstanceInfo() ([]VMInfo, []int, error) {
 		VMInfoList = append(VMInfoList, info)
 		coreIdxList = append(coreIdxList, coreIdx)
 	}
+
+	if err := rows.Err(); err != nil {
+		log.Error("Failed to iterate instance information rows: %v", err)
+		return nil, nil, err
+	}
+
 	return VMInfoList, coreIdxList, tx.Commit()
 }

--- a/structure/mysql_vm_repository.go
+++ b/structure/mysql_vm_repository.go
@@ -1,0 +1,184 @@
+package structure
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/easy-cloud-Knet/KWS_Control/util"
+)
+
+// MySQL VMRepository 구현체
+type MySQLVMRepository struct {
+	DB *sql.DB
+}
+
+func NewMySQLVMRepository(db *sql.DB) *MySQLVMRepository {
+	return &MySQLVMRepository{DB: db}
+}
+
+func (r *MySQLVMRepository) AddInstance(instanceInfo *VMInfo, coreIdx int) error {
+	log := util.GetLogger()
+	tx, err := r.DB.Begin()
+	if err != nil {
+		log.Error("Failed to start transaction %v", err)
+		return err
+	}
+	defer tx.Rollback()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = tx.ExecContext(ctx, "INSERT INTO inst_info (uuid, inst_ip, guac_pass, inst_mem, inst_vcpu, inst_disk) VALUES (?, ?, ?, ?, ?, ?)",
+		string(instanceInfo.UUID),
+		instanceInfo.IP_VM,
+		instanceInfo.GuacPassword,
+		instanceInfo.Memory,
+		instanceInfo.Cpu,
+		instanceInfo.Disk)
+	if err != nil {
+		log.Error("Failed to insert instance info: %v", err)
+		return err
+	}
+	_, err = tx.ExecContext(ctx, "INSERT INTO inst_loc (uuid, core) VALUES (?, ?)",
+		string(instanceInfo.UUID),
+		coreIdx)
+	if err != nil {
+		log.Error("Failed to insert instance core relation: %v", err)
+		return err
+	}
+	return tx.Commit()
+}
+
+func (r *MySQLVMRepository) UpdateInstance(instanceInfo *VMInfo) error {
+	log := util.GetLogger()
+	tx, err := r.DB.Begin()
+	if err != nil {
+		log.Error("Failed to start transaction %v", err)
+		return err
+	}
+	defer tx.Rollback()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err = tx.ExecContext(ctx, "UPDATE inst_info SET inst_ip = ?, inst_mem = ?, inst_vcpu = ?, inst_disk = ? WHERE uuid = ?",
+		instanceInfo.IP_VM,
+		instanceInfo.Memory,
+		instanceInfo.Cpu,
+		instanceInfo.Disk,
+		string(instanceInfo.UUID))
+	if err != nil {
+		log.Error("Failed to update instance info: %v", err)
+		return err
+	}
+	return tx.Commit()
+}
+
+func (r *MySQLVMRepository) DeleteInstance(uuid UUID) error {
+	log := util.GetLogger()
+	tx, err := r.DB.Begin()
+	if err != nil {
+		log.Error("Failed to start transaction: %v", err)
+		return err
+	}
+	defer tx.Rollback()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = tx.ExecContext(ctx, "DELETE FROM inst_info WHERE uuid = ?", uuid)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, "DELETE FROM inst_loc WHERE uuid = ?", uuid)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (r *MySQLVMRepository) GetInstance(uuid UUID) (*VMInfo, error) {
+	log := util.GetLogger()
+	tx, err := r.DB.Begin()
+	if err != nil {
+		log.Error("Failed to start transaction: %v", err)
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var instance VMInfo
+	err = tx.QueryRowContext(ctx, "SELECT uuid, inst_ip, guac_pass, inst_mem, inst_vcpu, inst_disk FROM inst_info WHERE uuid = ?", uuid).Scan(
+		&instance.UUID,
+		&instance.IP_VM,
+		&instance.GuacPassword,
+		&instance.Memory,
+		&instance.Cpu,
+		&instance.Disk)
+	if err != nil {
+		log.Error("Failed to get instance info: %v", err)
+		return nil, err
+	}
+	return &instance, tx.Commit()
+}
+
+func (r *MySQLVMRepository) GetInstanceLocation(uuid UUID) (int, error) {
+	log := util.GetLogger()
+	tx, err := r.DB.Begin()
+	if err != nil {
+		log.Error("Failed to start transaction: %v", err)
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var coreIdx int
+	err = tx.QueryRowContext(ctx, "SELECT core FROM inst_loc WHERE uuid = ?", uuid).Scan(&coreIdx)
+	if err != nil {
+		log.Error("Failed to get instance location: %v", err)
+		return 0, err
+	}
+	return coreIdx, tx.Commit()
+}
+
+func (r *MySQLVMRepository) GetAllInstanceInfo() ([]VMInfo, []int, error) {
+	log := util.GetLogger()
+	tx, err := r.DB.Begin()
+	if err != nil {
+		log.Error("Failed to start transaction: %v", err)
+		return nil, nil, err
+	}
+	defer tx.Rollback()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var rows *sql.Rows
+	rows, err = tx.QueryContext(ctx, "SELECT info.uuid, loc.core, info.inst_ip, info.guac_pass, info.inst_vcpu, info.inst_mem, info.inst_disk FROM inst_loc loc JOIN inst_info info ON loc.uuid = info.uuid")
+	if err != nil {
+		log.Error("Failed to get joined instance info: %v", err)
+		return nil, nil, err
+	}
+
+	var coreIdxList []int
+	var VMInfoList []VMInfo
+
+	for rows.Next() {
+		var coreIdx int
+		var info VMInfo
+
+		if err := rows.Scan(&info.UUID, &coreIdx, &info.IP_VM, &info.GuacPassword, &info.Cpu, &info.Memory, &info.Disk); err != nil {
+			log.Error("Failed to scan instance location: %v", err)
+			return nil, nil, err
+		}
+		log.DebugInfo("Found instance: %s on core %d", info.UUID, coreIdx)
+		VMInfoList = append(VMInfoList, info)
+		coreIdxList = append(coreIdxList, coreIdx)
+	}
+	return VMInfoList, coreIdxList, tx.Commit()
+}

--- a/structure/repository.go
+++ b/structure/repository.go
@@ -1,0 +1,12 @@
+package structure
+
+// VM 인스턴스의 데이터베이스 영속성 인터페이스
+// ControlContext에서 DB 관련 책임을 분리
+type VMRepository interface {
+	AddInstance(instanceInfo *VMInfo, coreIdx int) error
+	UpdateInstance(instanceInfo *VMInfo) error
+	DeleteInstance(uuid UUID) error
+	GetInstance(uuid UUID) (*VMInfo, error)
+	GetInstanceLocation(uuid UUID) (int, error)
+	GetAllInstanceInfo() ([]VMInfo, []int, error)
+}

--- a/structure/resource_manager.go
+++ b/structure/resource_manager.go
@@ -1,0 +1,23 @@
+package structure
+
+import "sync"
+
+// ResourceManager는 코어/VM의 런타임 인메모리 상태를 관리
+// ControlContext에서 뮤텍스와 상태 필드를 분리
+type ResourceManager struct {
+	mu         sync.RWMutex
+	Cores      []Core         // 모든 코어를 리스트
+	AliveVM    []*VMInfo      // 현재 가동중인 VM의 정보
+	VMLocation map[UUID]*Core // UUID 기반 VM  코어 위치 확인
+}
+
+func NewResourceManager() *ResourceManager {
+	return &ResourceManager{
+		VMLocation: make(map[UUID]*Core),
+	}
+}
+
+func (rm *ResourceManager) Lock()    { rm.mu.Lock() }
+func (rm *ResourceManager) Unlock()  { rm.mu.Unlock() }
+func (rm *ResourceManager) RLock()   { rm.mu.RLock() }
+func (rm *ResourceManager) RUnlock() { rm.mu.RUnlock() }

--- a/structure/resource_manager.go
+++ b/structure/resource_manager.go
@@ -1,6 +1,9 @@
 package structure
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 // ResourceManager는 코어/VM의 런타임 인메모리 상태를 관리
 // ControlContext에서 뮤텍스와 상태 필드를 분리
@@ -21,3 +24,94 @@ func (rm *ResourceManager) Lock()    { rm.mu.Lock() }
 func (rm *ResourceManager) Unlock()  { rm.mu.Unlock() }
 func (rm *ResourceManager) RLock()   { rm.mu.RLock() }
 func (rm *ResourceManager) RUnlock() { rm.mu.RUnlock() }
+
+// HardwareRequirement는 코어 선택 시 필요한 자원 요구량 구조체
+type HardwareRequirement struct {
+	Memory uint32 // MiB
+	CPU    uint32 // logical cores
+	Disk   uint32 // MiB
+}
+
+// CoreSelectionResult는 SelectCore의 반환값으로 진단 정보를 내포
+type CoreSelectionResult struct {
+	Core       *Core
+	Index      int
+	AliveCount int
+	TotalCores int
+}
+
+// SelectCore는 요청한 자원을 만족하는 첫 번째 살아있는 코어를 탐색.
+// RLock 범위 내에서 코어 슬라이스를 순회 (네트워크 콜은 호출자가 락 밖에서 수행).
+// 적합한 코어가 없으면 Core==nil로 반환하며, 진단 로그를 위한 카운트 정보를 함께 제공
+func (rm *ResourceManager) SelectCore(req HardwareRequirement) CoreSelectionResult {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	result := CoreSelectionResult{
+		Index:      -1,
+		TotalCores: len(rm.Cores),
+	}
+
+	for i := range rm.Cores {
+		core := &rm.Cores[i]
+		if !core.IsAlive {
+			continue
+		}
+		result.AliveCount++
+
+		if core.FreeMemory >= req.Memory && core.FreeCPU >= req.CPU && core.FreeDisk >= req.Disk {
+			result.Core = core
+			result.Index = i
+			return result
+		}
+	}
+	return result
+}
+
+// AllocateResources는 코어의 VMInfoIdx 맵에 VM을 등록하고 Free* 필드를 차감
+func (rm *ResourceManager) AllocateResources(core *Core, uuid UUID, vm *VMInfo, req HardwareRequirement) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	if core.VMInfoIdx == nil {
+		core.VMInfoIdx = make(map[UUID]*VMInfo)
+	}
+	core.VMInfoIdx[uuid] = vm
+	core.FreeMemory -= req.Memory
+	core.FreeCPU -= req.CPU
+	core.FreeDisk -= req.Disk
+}
+
+// DeallocateResources는 AllocateResources의 역연산
+func (rm *ResourceManager) DeallocateResources(core *Core, uuid UUID, req HardwareRequirement) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	delete(core.VMInfoIdx, uuid)
+	core.FreeMemory += req.Memory
+	core.FreeCPU += req.CPU
+	core.FreeDisk += req.Disk
+}
+
+// RegisterVM은 VMLocation 맵과 AliveVM 슬라이스에 VM을 동시에 등록
+func (rm *ResourceManager) RegisterVM(uuid UUID, core *Core, vm *VMInfo) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	rm.VMLocation[uuid] = core
+	rm.AliveVM = append(rm.AliveVM, vm)
+}
+
+// UnregisterAlive는 AliveVM 슬라이스에서 해당 UUID를 제거
+func (rm *ResourceManager) UnregisterAlive(uuid UUID) bool {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	for i, vm := range rm.AliveVM {
+		if vm.UUID == uuid {
+			rm.AliveVM = slices.Delete(rm.AliveVM, i, i+1)
+			return true
+		}
+	}
+	return false
+}

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -7,10 +7,11 @@ services:
     volumes:
       - ./init-test-db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ptestpass"]
+      test: ["CMD", "mysql", "-uroot", "-ptestpass", "-h", "127.0.0.1", "-P", "3306"]
       interval: 3s
       timeout: 5s
-      retries: 20
+      retries: 30
+      start_period: 50s
 
   redis-test:
     image: redis:7-alpine
@@ -39,6 +40,7 @@ services:
       context: ..
       dockerfile: Dockerfile
     container_name: kws-test-control
+    restart: on-failure:3
     ports:
       - "18081:8081"
     environment:


### PR DESCRIPTION
## Summary

갓 오브젝트였던 `ControlContext`를 **`VMRepository` 인터페이스**와 **`ResourceManager` 구조체**로 분리하여 DB 영속성 책임과 런타임 인메모리 상태 관리 책임을 명확히 구분했습니다.

## Motivation

1. **SRP 위반**: `structure/control_infra.go`의 `ControlContext`가 전체 서비스를 담당
2. **테스트 불가능**: DB 메서드의 강한 의존성으로 인한 단위 테스트 구현의 문제
3. **확장성 제약**: DB 엔진 교체, 동시성 전략 변경 등 변화 시 ControlContext 전체에 대한 변경 필요
4. **통합 테스트 플레이크**: MySQL healthcheck(`mysqladmin ping`)이 컨테이서 생성 시 통과하도록 되어있어 `control-test` 컨테이너의 DB 연결 실패로 인한 panic이슈 존재

## Approach

### 1. `VMRepository` 인터페이스 도입 (`structure/repository.go`)
- DB 영속성 계약을 인터페이스로 정의 (6개 메서드)
- `MySQLVMRepository` 구현체 분리 (`structure/mysql_vm_repository.go`)
- 향후 mock 구현체 주입으로 단위 테스트 가능

### 2. `ResourceManager` 구조체 도입 (`structure/resource_manager.go`)
- `sync.RWMutex` + `Cores` + `AliveVM` + `VMLocation`을 하나의 응집된 구조체로 묶음
- Lock/Unlock/RLock/RUnlock 메서드를 자체 제공

### 3. `ControlContext` 분리 (`structure/control_infra.go`)
- `VMRepo VMRepository` + `Resources *ResourceManager` 조합 구조로 변경
- `FindCoreByVmUUID()`는 리포지토리와 리소스 매니저를 조율하는 얇은 오케스트레이션 계층으로 유지

### 4. 호출부 전면 업데이트
- `service/vm.go`: `contextStruct.AddInstance()` → `contextStruct.VMRepo.AddInstance()`, Lock/Cores/VMLocation/AliveVM 접근을 `contextStruct.Resources.*`로 전환
- `service/guacamole.go`, `service/network.go`: RLock/VMLocation 접근 경로 업데이트
- `startup/init.go`: `NewMySQLVMRepository()`, `NewResourceManager()` 초기화 플로우 적용
- `main.go`: `contextStruct.Cores` → `contextStruct.Resources.Cores`

### 5. MySQL healthcheck 강화 (`tests/docker-compose.test.yml`)
- `mysqladmin ping` → `mysql -e "SELECT 1"`로 변경하여 실제 TCP 연결 준비 상태를 검증
- `retries: 30`, `start_period: 10s` 적용

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Docs / Config
- [ ] CI/CD

## Related Issue
#37 

## Testing
- [x] Tested locally
  - [x] `go build ./...`, `go vet ./...` 에러 없이 통과
  - [x] 통합 테스트 (`bash tests/blackbox_io_test.sh`) 전체 **66/66 PASS**
    - Section 1: HTTP Method Routing (8)
    - Section 2: Invalid JSON Body (7)
    - Section 3: Field Validation (4)
    - Section 4: Non-existent UUID (5)
    - Section 5: Happy Path — VM Lifecycle (Create → Info → Start → Status → Shutdown → Delete) (13)
    - Section 6: Redis Endpoints (29)
- [x] No regression in existing functionality

## Follow-ups (이번 PR 범위 외)
- Step 2
  - `CreateVM()`의 8가지 이상의 책임을 `Orchestrator` 패턴으로 분리
  - `CmsClient`를 `service/` → `client/` 패키지로 이동 (다른 PR이 담당 중)
- Step 3
  - `startup/init.go` 초기화 로직 분할: DB 초기화 / 코어 헬스체크 / VM 상태 복원
  - `pkg/guacamole/config.go`의 10단계 단일 함수를 모듈별로 분할

## Checklist

- [x] Reviewers assigned
- [x] Related issue linked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal resource management and database persistence layers for improved modularity and concurrency control.

* **Tests**
  * Enhanced test infrastructure with improved MySQL container health verification and automatic restart policies for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->