### PR TITLE
feat: wire snapshot TakeExternalSnapshot to Core endpoint

### DIFF
--- a/client/model/snapshot.go
+++ b/client/model/snapshot.go
@@ -10,5 +10,6 @@ type TakeSnapshotRequest struct {
 }
 
 type TakeSnapshotResponse struct {
-	Message string `json:"message,omitempty"`
+	UUID    string `json:"uuid"`
+	SnapKey string `json:"snapKey"`
 }

--- a/client/vm.go
+++ b/client/vm.go
@@ -183,3 +183,17 @@ func (c *CoreClient) ForceShutdownVM(ctx context.Context, req model.ForceShutdow
 	}
 	return response, nil
 }
+
+// TakeExternalSnapshot asks Core to take a snapshot and upload it to RustFS via the given presigned PUT URL.
+// Uses a dedicated HTTP client with a 12-minute timeout because snapshot creation + upload can take several minutes.
+func (c *CoreClient) TakeExternalSnapshot(ctx context.Context, req model.TakeSnapshotRequest) (model.TakeSnapshotResponse, error) {
+	snapClient := &CoreClient{
+		baseURL: c.baseURL,
+		client:  &http.Client{Timeout: 12 * time.Minute},
+	}
+	var response model.TakeSnapshotResponse
+	if err := snapClient.doRequest(ctx, http.MethodPost, "/TakeExternalSnapshot", req, &response); err != nil {
+		return model.TakeSnapshotResponse{}, err
+	}
+	return response, nil
+}

--- a/service/external_snap.go
+++ b/service/external_snap.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/easy-cloud-Knet/KWS_Control/client"
+	"github.com/easy-cloud-Knet/KWS_Control/client/model"
 	vms "github.com/easy-cloud-Knet/KWS_Control/structure"
 )
 
@@ -52,9 +53,13 @@ func TakeSnapshot(uuid vms.UUID, snapName string, ctx *vms.ControlContext) error
 		return fmt.Errorf("TakeSnapshot %s: failed to generate presigned URL: %w", uuid, err)
 	}
 
-	// TODO: coreClient.TakeSnapshot(context.Background(), model.TakeSnapshotRequest{
-	//     UUID: uuid, SnapKey: snapName, PresignedURL: presignedURL,
-	// })
-	_ = presignedURL
+	coreClient := client.NewCoreClient(core)
+	if _, err := coreClient.TakeExternalSnapshot(context.Background(), model.TakeSnapshotRequest{
+		UUID:         uuid,
+		SnapKey:      snapName,
+		PresignedURL: presignedURL,
+	}); err != nil {
+		return fmt.Errorf("TakeSnapshot %s: core failed: %w", uuid, err)
+	}
 	return nil
 }


### PR DESCRIPTION
#WIP

## Summary

- `TakeSnapshotResponse` 를 Core 응답 스펙(`uuid`, `snapKey`)에 맞게 수정
- `CoreClient.TakeExternalSnapshot` 추가 — `POST /TakeExternalSnapshot` 호출, 스냅샷 생성+업로드 소요 시간 고려해 12분 timeout 전용 클라이언트 사용
- `service/external_snap.go:TakeSnapshot` TODO 제거 — presigned PUT URL 발급 후 Core에 실제 전달하는 흐름 완성

## Paired PR

이 PR은 Core 측 구현과 페어로 동작합니다.

**Core PR #152**: https://github.com/easy-cloud-Knet/KWS_Core/pull/152
#### 현재 코어에 해당 엔드포인트가 개발이 된 상태입니다. 
#### 두 Pr 을 기준으로  Control ↔ Core end-to-end 테스트를 진행하고, 통과 시 본 PR을 머지합니다.
#### 현재 컨트롤의 서비스 로직은 단순히 엔드포인트가 돌아걸 정도의 최소 구현입니다 .  
#### 추후에 db 조작등+ 인증, 롤백등 구현을 통해 서비스 로직이 추가될거에요

## Flow

```
POST /vm/snapshot (Control)
  → RustFS: presigned PUT URL 발급
  → Core POST /TakeExternalSnapshot (presignedUrl 전달)
    → Core: 스냅샷 생성 + RustFS 직접 업로드
```

## WIP / Merge Condition

- [ ] Core PR #152 머지 완료
- [ ] Control ↔ Core e2e 테스트 통과 (`POST /vm/snapshot` → RustFS 버킷 확인)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for taking external snapshots through the app’s snapshot flow.
  * Snapshot responses now return a snapshot UUID and key, enabling clearer tracking of created snapshots.

* **Bug Fixes**
  * Completed the snapshot creation path so the system now calls the backend instead of stopping at a placeholder.
  * Improved error handling when snapshot creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->