### PR TITLE
fix: bump Dockerfile golang base image to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS build
+FROM golang:1.25 AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- 보안 알람때문에( golang.org/x/crypto  PR #73 ), go mod 의 go 버전이 호환안되는 문제 발생
go > 1.25 이상이 필요함.

go 버전에 아직은 크게 구애받지 않는것 같아 업그레이드 했습니당


## Test plan
- [x] `docker build --no-cache -t control_dev:test .` succeeds locally